### PR TITLE
Add Linux installer and 7-day update timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,330 +1,88 @@
 # Zen Browser
 
-An open-source, privacy-first desktop web browser built on Electron. Zen Browser is designed to give Linux and power users a browser that is honest about what it does: blocking ads at the network level, protecting your fingerprint, forcing encrypted connections, giving you full control of your privacy settings, and integrating an AI assistant without sending your data to unknown third parties.
+Zen Browser is an experimental desktop browser shell built with Electron. The goal is to shape it into a Linux-first browser for controlled web apps, practical privacy controls, and local-first AI assistance.
 
-This project is open to anyone. Fork it. Break it. Improve it. Submit pull requests. The more people who contribute, the better this gets.
+This is not a finished Chrome, Brave, Firefox, or Arc replacement yet. It is a prototype that needs hardening before anyone should trust it as a daily driver.
 
----
-
-## Table of Contents
+## Current status
 
-1. [The Original Idea](#the-original-idea)
-2. [What This Browser Actually Is](#what-this-browser-actually-is)
-3. [Feature List](#feature-list)
-4. [WhatsApp on Linux: The Problem and the Solution](#whatsapp-on-linux-the-problem-and-the-solution)
-5. [OpenClaw AI Integration](#openclaw-ai-integration)
-6. [Cloud Sync with MEGA](#cloud-sync-with-mega)
-7. [Privacy Architecture](#privacy-architecture)
-8. [Getting Started](#getting-started)
-9. [Running OpenClaw](#running-openclaw)
-10. [Project Structure](#project-structure)
-11. [Contributing](#contributing)
-12. [Known Limitations and Roadmap](#known-limitations-and-roadmap)
-13. [License](#license)
-
----
-
-## The Original Idea
-
-Most browsers are built around a business model. Google Chrome exists to feed Google's advertising network. Microsoft Edge exists to push Microsoft services. Even some privacy-focused browsers have commercial incentives that eventually shape their decisions.
-
-The original idea for Zen Browser was to build something that has no such incentive. A browser where the code is in front of you, where every privacy feature is visible and toggleable and explained, and where integrating an AI assistant does not mean routing your conversations through a Silicon Valley server farm.
-
-The specific problems this browser was designed to address:
-
-1. Linux users are treated as second-class citizens by web services. WhatsApp Web does not offer video calls on Linux because it detects the operating system and removes the feature. This is not a technical limitation. Chromium on Linux is fully capable of video calls. It is a deliberate product decision. This browser works around it.
-
-2. AI assistants in browsers are typically either cloud-only (your data leaves your machine) or non-existent. This browser integrates OpenClaw, a self-hosted AI gateway that can run entirely on your own hardware.
-
-3. Privacy settings in most browsers are buried, vague, and often ineffective. This browser exposes every privacy control on a dedicated screen with plain-language descriptions of what each setting does.
-
-4. Cross-device sync in other browsers requires creating an account with the browser vendor. This browser uses your own MEGA cloud storage, which you control.
-
----
-
-## What This Browser Actually Is
+Version: `v0.1 Foundation`
 
-Zen Browser is an Electron application. That means it runs the Chromium rendering engine inside a Node.js application shell. It is not a fork of Firefox or a Chromium extension. It is a custom application that uses Chromium's web rendering capabilities while giving you full control over the surrounding environment.
-
-When you browse a website in Zen Browser, the web page is rendered by the same engine that powers Google Chrome. The difference is everything that happens before and around that rendering: request blocking, user-agent handling, session isolation, and the shell you see on screen.
+The current codebase can render web pages through Electron's Chromium engine and includes early versions of tabs, app profiles, privacy toggles, bookmarks, RSS, MEGA sync, and an OpenClaw AI panel.
 
-This is a trade-off worth understanding. Being Electron-based means:
-- Memory usage is higher than a native browser. Electron loads a full Chromium instance.
-- You get fine-grained control over network requests in a way that pure browser extensions cannot achieve.
-- The privacy features operate at the application layer, not the extension layer, which means they cannot be disabled by a website.
+The important work now is to make the project honest, stable, testable, and easier to improve.
 
----
+## What this browser is trying to become
 
-## Feature List
+A focused browser for people who want:
 
-### Core Browsing
-- Full Chromium rendering engine via Electron's BrowserView
-- Unlimited tabs with persistent state across restarts
-- Tab titles, favicons, and URLs persist between sessions
-- Back, forward, and reload navigation
-- Split-screen mode: two tabs side by side simultaneously
-- Keyboard shortcut to open the command palette (Ctrl+K or Ctrl+L)
-- Custom new tab home page with clock, search bar, and speed dial links
+- Linux-first desktop browsing
+- web apps in isolated sessions
+- clear privacy controls instead of hidden settings
+- optional local-first AI assistance
+- no browser-vendor account requirement for basic usage
+- practical tools for builders, researchers, and power users
 
-### Search Engines
-- DuckDuckGo (default, private)
-- Startpage (Google proxied, private)
-- Qwant (EU-based, private)
-- Google (when needed)
-- Switch engines per-session from the home screen
+## What it is not yet
 
-### Privacy and Security
-- Network-level ad and tracker blocking using a host blocklist (Ad Shield)
-- Browser fingerprint randomization that changes the User-Agent header on every request (Fingerprint Cloak)
-- Automatic HTTP to HTTPS upgrade for all requests (Force HTTPS)
-- JavaScript blocking mode for maximum script isolation (Script Fortress)
-- WhatsApp Windows environment spoofing to unlock video calls on Linux (Deep Spoof)
-- All privacy settings are toggleable from the Security screen and take effect immediately without restarting
-- History retention with configurable window: 24 hours, 7 days, 30 days, or forever
+Zen Browser is not yet:
 
-### Web Apps
-The Apps section launches a curated set of web services in isolated, persistent sessions:
-- WhatsApp Web (with Windows spoof, enabling video calls on Linux)
-- Netflix
-- Spotify
-- GitHub
-- ChatGPT
-Each app uses its own browser partition, so your WhatsApp session is completely separate from your normal browsing session. Cookies, local storage, and site data do not bleed between partitions.
+- a full privacy browser
+- an anonymity tool
+- a hardened security browser
+- a complete replacement for mainstream browsers
+- a production-ready password/session manager
+- a proven WhatsApp calling solution across all accounts and future WhatsApp updates
 
-### AI Assistant: OpenClaw
-- Integrated AI panel that slides in from the sidebar
-- Connects to your own locally-running OpenClaw gateway (runs on localhost:3008)
-- The AI is told what page you are currently viewing, its title, and URL so it can answer questions about it
-- One-click actions: Summarize page, Key points, Explain simply
-- If OpenClaw is not running, the panel shows its status and gives you a Start button that launches the Docker container
-- The AI never phones home to a third party unless OpenClaw itself is configured to do so on your behalf
-- Context updates automatically when you switch tabs
+## Core features in the prototype
 
-### Reader: Live RSS
-- Fetches live articles from Hacker News, Ars Technica, The Register, Wired, and Linux Today
-- Click any article to open it in a browser tab
-- Filter by source
-- Refresh on demand
+### Browsing
 
-### Library: Bookmarks
-- Add and delete bookmarks
-- Organize bookmarks into folders: General, Work, Research, Tech, Media
-- Search across all bookmarks by title or URL
-- Favicons loaded automatically
-- Stored in local storage, persists across restarts
+- Electron `BrowserView` based Chromium rendering
+- tabs with persisted basic state
+- navigation controls
+- split-screen tab view
+- custom app shell
 
-### Dashboard
-- Live CPU usage percentage
-- Live RAM usage in GB with a visual bar
-- Local browser storage usage
-- Secure scratchpad that auto-saves to local storage (not synced, not sent anywhere)
-- Quick access buttons to GitHub, Reddit, ProtonMail, Discord
+### Web apps
 
-### Sync: MEGA Cloud Storage
-- Optional cloud sync of your browser profile using your own MEGA.nz account
-- Your data is encrypted before upload using MEGA's own client-side encryption
-- Auto-syncs every 5 minutes when logged in
-- Upload includes tabs, history, and settings
-- No Zen-controlled servers. Your data goes from your machine to your MEGA account.
+- app launcher for common web services
+- isolated persistent partitions for launched apps
+- WhatsApp Web profile with Windows user-agent spoofing experiment for Linux calling support
 
-### Window Controls
-- Frameless window with custom title bar
-- Minimize, maximize, and close
-- Sidebar collapse/expand toggle
-- The sidebar can run collapsed (icon-only) to give maximum browsing space
+### Privacy controls
 
----
+- simple ad/tracker host blocking
+- HTTPS upgrade attempt for HTTP URLs
+- optional user-agent spoofing
+- configurable history retention
+- local storage through Electron `safeStorage` when available
 
-## WhatsApp on Linux: The Problem and the Solution
+These controls are early. They should be treated as practical experiments, not strong privacy guarantees.
 
-WhatsApp Web at web.whatsapp.com serves different JavaScript depending on the browser and operating system it detects. On Linux browsers, WhatsApp disables the video call UI. This is not a Chromium limitation. It is detected and enforced by WhatsApp's JavaScript, which checks `navigator.platform` and the `User-Agent` header.
+### AI panel
 
-Zen Browser solves this with a two-layer spoof:
+- OpenClaw panel in the sidebar
+- local gateway status check
+- current page title and URL can be passed as context
 
-Layer 1 is at the HTTP header level. When any request is made to web.whatsapp.com, the outgoing `User-Agent` header is replaced with a Windows Chrome Electron string before the request leaves your machine:
+The AI layer should remain explicit and user-controlled. The browser should not silently scrape or send page content.
 
-```
-Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) WhatsApp/2.24.4.78 Chrome/120.0.6099.225 Electron/30.0.0 Safari/537.36
-```
+### Other tools
 
-This happens in `src/main/main.ts` inside the `onBeforeSendHeaders` hook, which intercepts every HTTP request. The replacement is exact and happens before any JavaScript on the page can affect it.
+- bookmarks
+- RSS reader
+- dashboard
+- MEGA profile sync experiment
 
-Layer 2 is at the JavaScript level. When WhatsApp navigates, a script is injected that overrides `navigator.platform` to return `Win32` and overrides `navigator.userAgent` to return the Windows string. This ensures that WhatsApp's own JavaScript, even after the page has loaded, sees a consistent Windows environment.
+## Setup
 
-Camera and microphone permissions are automatically granted to WhatsApp without prompting, which is required for video calls to function.
+Requirements:
 
-To use this:
-1. Open the Apps section in the sidebar
-2. Click WhatsApp
-3. Scan the QR code as usual
-4. The video call button should now appear in conversations
-
-If it does not work, check that Deep Spoof is enabled in the Security section.
-
----
-
-## OpenClaw AI Integration
-
-OpenClaw is an open-source AI gateway that can be self-hosted. It supports multiple AI backends including Google Gemini, NVIDIA, and Claude. The Zen Browser integration treats OpenClaw as a local service and communicates with it over HTTP on localhost.
-
-### Architecture
-
-The OpenClaw gateway runs as a Docker container, typically at port 3008. The Zen Browser's main process can start or stop this container. The renderer process (the browser UI) communicates with the gateway directly using the Fetch API since it is connecting to localhost.
-
-When you open the OpenClaw panel:
-1. The panel immediately checks if the gateway is reachable at http://localhost:3008/health
-2. The status indicator shows green (online), amber (checking), or red (offline)
-3. If offline, a Start button calls an IPC handler in the main process which runs the appropriate Docker command
-4. When you send a message, the current page's URL and title are included in the system prompt sent to the AI
-5. The AI can therefore see what you are reading and answer questions about it
-
-### What the AI knows
-When you are browsing web.whatsapp.com and ask the AI a question, the system prompt includes: "The user is currently viewing: WhatsApp Web at https://web.whatsapp.com". The AI uses this to provide contextually relevant answers.
-
-### Running OpenClaw (see full section below)
-
----
-
-## Running OpenClaw
-
-OpenClaw requires Docker. You need to have Docker installed and your user added to the docker group.
-
-### Step 1: Get OpenClaw
-
-OpenClaw is located at https://github.com/openclaw/openclaw (check their repository for the latest instructions). You can also use a local build.
-
-### Step 2: Create your environment file
-
-Navigate to where OpenClaw's docker-compose.yml is located and create an environment file. You need at minimum a Google API key (free tier from Google AI Studio) to use the Gemini model:
-
-```
-OPENCLAW_GATEWAY_TOKEN=your-token-here
-GOOGLE_API_KEY=your-key-here
-OPENCLAW_CONFIG_DIR=/home/youruser/.openclaw/config
-OPENCLAW_WORKSPACE_DIR=/home/youruser/.openclaw/workspace
-```
-
-### Step 3: Start the gateway
-
-```bash
-docker compose up -d openclaw-gateway
-```
-
-The gateway will be available at http://localhost:3008.
-
-### Step 4: Verify it is running
-
-```bash
-curl http://localhost:3008/health
-```
-
-If you see a 200 OK response, OpenClaw is running and the Zen Browser panel will connect to it.
-
-### From inside Zen Browser
-
-If OpenClaw is not running, open the OpenClaw panel (Bot icon in the sidebar) and click the Start button. This triggers the main process to run the Docker command for you. The status indicator will turn green once the container is ready (this may take a few seconds).
-
-### Troubleshooting
-
-If the status stays red:
-- Check that Docker is running: `systemctl status docker`
-- Check container logs: `docker logs openclaw-gateway`
-- Make sure port 3008 is not blocked by a firewall
-- Make sure your environment file has valid API keys
-
----
-
-## Cloud Sync with MEGA
-
-MEGA is an end-to-end encrypted cloud storage service. Zen Browser uses the `megajs` library to upload your local profile data to your MEGA account.
-
-### What is synced
-
-The sync uploads a single file called `user-data.json` to a folder named `ZenBrowserSync` in your MEGA account. This file contains:
-- Open tab list and URLs
-- Browsing history
-- Privacy settings
-- Active tab preference
-
-Passwords are not synced. Cookies are not synced. Session data is not synced.
-
-### How to set it up
-
-1. Open Preferences (gear icon in the sidebar)
-2. Find the MEGA.nz Cloud Sync section
-3. Enter your MEGA email and password
-4. Click Login
-
-The browser will connect to MEGA, create the ZenBrowserSync folder if it does not exist, and upload your current profile. Sync runs automatically every 5 minutes after that.
-
-### Security note
-
-Your MEGA password is sent to MEGA's servers over HTTPS to authenticate. The `megajs` library handles this. Your data is encrypted on your machine before upload using MEGA's client-side encryption, which means MEGA's servers cannot read the content. If you use a two-factor-authenticated MEGA account, you will need an app password.
-
----
-
-## Privacy Architecture
-
-Understanding exactly what Zen Browser does and does not do to protect your privacy.
-
-### What happens to your requests
-
-Every outgoing HTTP and HTTPS request from a browser tab goes through the Electron session's `webRequest` API hooks before it leaves your machine. Zen Browser registers two hooks:
-
-`onBeforeRequest`: This hook inspects the URL of every request. If Ad Shield is enabled, the URL is checked against a blocklist of known advertising, analytics, and tracking domains. If the URL matches, the request is cancelled before it is sent. The website never receives any signal that the request was blocked.
-
-`onBeforeSendHeaders`: This hook inspects and modifies the HTTP headers of every request. If Fingerprint Cloak is enabled, the `User-Agent` header is replaced with a randomly selected one from a pool of common, real browser strings. If Deep Spoof is enabled and the request is going to WhatsApp, the User-Agent is replaced with the Windows WhatsApp string instead.
-
-These hooks run at the main process level, not inside the web page. This means a website's JavaScript cannot detect or override them.
-
-### What is stored locally
-
-All browser state is stored in a single JSON file at:
-```
-~/.config/zen-browser/user-data.json
-```
-On Linux, this is typically:
-```
-~/.config/Electron/user-data.json
-```
-
-If Electron's `safeStorage` API is available (which it is on most modern Linux systems with a keyring), this file is encrypted using the system's secret service before being written to disk. The encryption uses the same mechanism as Chrome's "OS-level encryption" on Linux.
-
-The scratchpad on the Dashboard is stored in the renderer process's `localStorage`, which Electron maps to a file in the user data directory as well. It is not in the main user-data.json.
-
-### What leaves your machine
-
-When you browse a website, HTTP requests go to that website's servers. This is unavoidable.
-
-The RSS reader uses the `allorigins.win` CORS proxy to fetch RSS feeds from news sites. The proxy sees which feed URLs you are fetching.
-
-When you use OpenClaw, your messages and the current page URL are sent to your locally-running OpenClaw gateway. What the gateway does with them depends on which AI backend you have configured. If you use Google Gemini, your message goes to Google's API. You are in control of this. If it concerns you, run a local model.
-
-Favicons in the Bookmarks view are fetched from Google's favicon service (`https://www.google.com/s2/favicons`) using the domain of the bookmarked URL. Google sees which domains you have bookmarked. If this concerns you, the favicon loading can be removed from `src/renderer/views/BookmarksView.tsx`.
-
-The MEGA sync sends your user-data.json to MEGA's servers, encrypted.
-
-Nothing else leaves your machine. There are no analytics, no crash reports, no telemetry, no calls to any Zen Browser server because there is no Zen Browser server.
-
----
-
-## Getting Started
-
-### Requirements
-
-- Node.js 18 or later
-- npm 9 or later
-- A Linux system (also works on macOS and Windows but the WhatsApp spoof is most relevant on Linux)
-- Docker (optional, required for OpenClaw AI integration)
-
-### Installation
-
-Clone the repository:
-
-```bash
-git clone https://github.com/imranshiundu/zen-browser.git
-cd zen-browser
-```
+- Node.js 18 or newer
+- npm 9 or newer
+- Electron-supported desktop OS
+- Linux recommended for the current direction
 
 Install dependencies:
 
@@ -332,181 +90,95 @@ Install dependencies:
 npm install
 ```
 
-Build the application:
-
-```bash
-npm run build
-```
-
-Start the browser:
-
-```bash
-npm start
-```
-
-Or do both in one command:
+Run a development build:
 
 ```bash
 npm run dev:start
 ```
 
-### Development mode with hot reload
-
-For development, run the webpack watcher in one terminal:
+Build only:
 
 ```bash
-npm run dev
+npm run build
 ```
 
-Then in another terminal, start the Electron application:
+Run type checking:
+
+```bash
+npm run typecheck
+```
+
+Run the basic verification command:
+
+```bash
+npm run verify
+```
+
+Start the app:
 
 ```bash
 npm start
 ```
 
-When you change a source file, webpack rebuilds it. You can then press Ctrl+R in the browser window or use the reload option to pick up changes.
+Only use the unsafe no-sandbox command when debugging a local environment that requires it:
 
----
-
-## Project Structure
-
-```
-zen-browser/
-  src/
-    main/
-      main.ts           - Electron main process, IPC handlers, BrowserView management
-      storage.ts        - Encrypted local storage read/write
-      sync.ts           - MEGA cloud sync service
-      auth.ts           - Google account authentication handlers
-      privacy-filters.ts - Ad blocking host list and user agent rotation
-    preload/
-      preload.ts        - Secure bridge between renderer and main process using contextBridge
-    renderer/
-      App.tsx           - Root component, tab orchestration, OpenClaw panel toggle
-      components/
-        Sidebar.tsx     - Left navigation with tab list and utility menu
-        TitleBar.tsx    - Frameless window controls
-        TabStrip.tsx    - Browser tab bar shown above web content
-        NavigationBar.tsx - Back, forward, reload, URL input
-        SettingsModal.tsx - Privacy settings and MEGA sync UI
-        OpenClawPanel.tsx - AI assistant panel with context-aware chat
-      views/
-        Home.tsx        - New tab home screen with clock, search, speed dial
-        Dashboard.tsx   - System metrics, scratchpad, quick access
-        Browser.tsx     - Wrapper for the BrowserView content area
-        Apps.tsx        - Web app launcher with isolated sessions
-        RSSView.tsx     - Live RSS reader (Hacker News, Ars Technica, Wired, etc.)
-        BookmarksView.tsx - Bookmark manager with folders and search
-        PrivacyView.tsx - Live privacy settings with descriptions
-        ExtensionsView.tsx - Browser module overview
-      electron.d.ts     - TypeScript types for the IPC bridge
-      types.ts          - Shared TypeScript types
-  package.json
-  webpack.config.js
-  tsconfig.json
+```bash
+npm run start:unsafe-no-sandbox
 ```
 
----
+## Project structure
 
-## Contributing
+```text
+src/
+  main/        Electron main process, BrowserView management, storage, sync, privacy filters
+  preload/     safe bridge exposed to the renderer
+  renderer/    React interface, views, panels, navigation, settings
 
-This project is open source. Contributions of all kinds are welcome.
+docs/
+  rebuild-plan.md
+```
 
-### How to contribute
+## Known problems
 
-1. Fork the repository on GitHub
-2. Create a branch for your change: `git checkout -b my-feature`
-3. Make your changes
-4. Build and test: `npm run build && npm start`
-5. Commit your changes with a clear message
-6. Push to your fork and open a pull request
+These are not small issues. They are the reason the browser needs a rebuild path.
 
-### What to work on
+1. The ad/tracker blocker uses a small hard-coded list, not maintained filter lists.
+2. Random user-agent rotation can make fingerprinting worse if used incorrectly.
+3. Some README claims were stronger than the implementation.
+4. The project has no automated tests yet.
+5. RSS currently depends on renderer-side fetching patterns that should move to the main process.
+6. Cloud sync needs stronger conflict handling and clearer data boundaries.
+7. IPC actions need tighter validation as the browser grows.
+8. Packaging is not ready for normal users.
+9. The app needs a clean release mode that does not behave like a development build.
 
-The following areas need the most work:
+## Rebuild path
 
-**RSS Reader improvements**: The reader currently uses a CORS proxy which adds a dependency on a third-party service. The main process could fetch RSS feeds directly using Node.js's `https` module and pass the parsed results to the renderer via IPC. This would remove the external dependency.
+Use simple version names:
 
-**Bookmarks**: Currently stored in `localStorage` which is tied to the renderer session. Moving bookmarks into the main process's `StorageService` would make them part of the encrypted user-data.json and sync-able with MEGA.
+- `v0.1 Foundation` — honest docs, build scripts, verification, project contract
+- `v0.2 Stable Tabs` — reliable tab restore, navigation state, crash handling
+- `v0.3 Web Apps` — isolated app profiles, permissions, reset controls
+- `v0.4 Privacy Controls` — maintained filters, allowlists, visible blocked counts, stable fingerprint profile
+- `v0.5 Local Assistant` — streaming, explicit context, provider settings, local/cloud warnings
+- `v0.6 Sync` — safe sync scope, conflict handling, manual export/import
+- `v0.7 Packaging` — AppImage, deb, icons, desktop entry
+- `v1.0 Daily Driver` — only after stability, packaging, tests, and privacy docs match behavior
 
-**History view**: There is history being tracked (visible in the storage data) but there is no UI to view or search it.
+Read the detailed plan in [`docs/rebuild-plan.md`](docs/rebuild-plan.md).
 
-**Download manager**: Electron has a download manager API but it is not wired up. Files currently download through the default Electron behavior with no UI.
+## Contribution rules
 
-**Extensions**: The Extensions view currently shows a static list of built-in privacy modules. A real extension loader that imports Chrome extensions using Electron's extension API would be a significant but achievable addition.
+Keep the project plain and professional.
 
-**OpenClaw streaming**: The current API call waits for a complete response. OpenClaw's gateway supports streaming responses over SSE (Server-Sent Events). Wiring this up would make the AI responses feel much more responsive.
-
-**Logo**: The project needs a proper logo. The current text-based Zen wordmark in the sidebar is a placeholder. A proper icon file would replace the default Electron icon in the window title bar and taskbar.
-
-**Test coverage**: There are currently no automated tests. Adding tests for the storage service, the privacy filter URL matching, and the IPC handlers would make the project more maintainable.
-
-### Code style
-
-The project uses TypeScript throughout. Keep types explicit. Avoid `any` where a proper type is possible. The renderer uses React functional components with hooks. The main process is plain TypeScript using Electron's Node.js APIs.
-
-There is no linter configuration yet. A PR adding ESLint with sensible defaults would be welcome.
-
----
-
-## Known Limitations and Roadmap
-
-### Current limitations
-
-**Memory usage**: Because Zen Browser runs Chromium through Electron, it uses more memory than a native browser like Firefox. Each open tab is a BrowserView running in a shared Chromium process. This is similar to how Chrome works but the overhead of the Electron shell adds to it.
-
-**No extensions from the Chrome Web Store**: While Electron supports loading Chrome extensions, there is no UI or mechanism to install them from the Chrome Web Store. Privacy-essential extensions like uBlock Origin cannot currently be added. The built-in Ad Shield covers the most common use case.
-
-**WhatsApp video calls**: The Windows spoof works to display the video call UI. Whether calls fully connect depends on WhatsApp's server-side checks, which vary and change over time. Some users may find voice calls work but not video, or that they need to update to a new User-Agent string. The UA string can be changed in `src/main/main.ts` at the `WHATSAPP_UA` constant.
-
-**OpenClaw Chat API endpoint**: The current integration posts to `/api/chat` on the OpenClaw gateway. The exact endpoint structure depends on the version of OpenClaw you are running. If your AI calls return errors, check the OpenClaw documentation for the correct endpoint and update `src/renderer/components/OpenClawPanel.tsx`.
-
-**RSS CORS proxy**: The RSS feeds are fetched through `allorigins.win`. If this proxy is down or rate-limited, the RSS reader will fail. Moving feed fetching to the main process is the right long-term solution.
-
-**Storage encryption falling back to plaintext**: On systems without a keyring daemon (some minimal Linux installs), `safeStorage.isEncryptionAvailable()` returns false and the user-data.json is stored as plaintext. A warning should be shown to the user in this case.
-
-### Roadmap (not committed, ideas only)
-
-- History view with search
-- Download manager UI
-- Password manager with local encryption
-- Custom CSS injection per-site
-- Vertical tab bar option
-- Reader mode that strips page formatting for long articles
-- Extension loader (unpacked Chrome extensions)
-- Per-site granular settings (block scripts on some sites but not others)
-- Tab grouping
-- Session save and restore
-- Dark/light mode toggle (currently dark only)
-
----
+- Do not oversell features.
+- Do not add fake privacy claims.
+- Do not add hidden telemetry.
+- Do not send page content to AI providers without explicit user action.
+- Prefer small verified patches over huge rewrites.
+- Keep names simple and readable.
+- Document every feature that touches user data.
 
 ## License
 
-This project is released under the MIT License. You can use it, copy it, modify it, and distribute it for any purpose, including commercial use, with or without changes. The only requirement is that the license notice is preserved.
-
-```
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
----
-
-This project is not affiliated with, endorsed by, or connected to any company. It is an independent open-source project. If you decide to use it, you are responsible for your own browsing activity and any data you choose to sync or share.
+MIT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zen Browser
 
-Zen Browser is an experimental desktop browser shell built with Electron. The goal is to shape it into a Linux-first browser for controlled web apps, practical privacy controls, and local-first AI assistance.
+Zen Browser is an experimental desktop browser shell built with Electron. The goal is to shape it into a Linux-first browser for controlled web apps, DuckDuckGo-first search, practical privacy controls, encrypted local data where possible, and local-first AI assistance.
 
 This is not a finished Chrome, Brave, Firefox, or Arc replacement yet. It is a prototype that needs hardening before anyone should trust it as a daily driver.
 
@@ -12,13 +12,46 @@ The current codebase can render web pages through Electron's Chromium engine and
 
 The important work now is to make the project honest, stable, testable, and easier to improve.
 
+## What makes a real browser real?
+
+A real browser is not just an app that opens a website. A real browser needs:
+
+- a modern rendering engine
+- address/search navigation
+- tabs and session restore
+- bookmarks and history
+- downloads
+- permissions for camera, microphone, notifications, location, and clipboard
+- storage boundaries
+- crash recovery
+- security controls
+- update/install packaging
+- clear privacy behavior that matches the code
+
+Zen already has the beginning of the rendering, navigation, tabs, app profiles, bookmarks, and privacy layers. It still needs stronger downloads, permissions UI, crash recovery, tests, packaging, and privacy hardening before it can be called a daily-driver browser.
+
+See [`docs/real-browser-checklist.md`](docs/real-browser-checklist.md).
+
+## Product identity
+
+Zen should become useful first as:
+
+> A Linux-first browser for DuckDuckGo search, isolated web apps, practical privacy controls, encrypted local profile data where available, and optional local AI help.
+
+DuckDuckGo is the default search identity. Startpage and Qwant are privacy alternatives. Google can exist as a user-selected fallback, but it should not define the browser.
+
+WhatsApp support matters. It should remain one of the strongest web-app profiles, especially for Linux users, but the browser should not become only a WhatsApp wrapper.
+
 ## What this browser is trying to become
 
 A focused browser for people who want:
 
-- Linux-first desktop browsing
-- web apps in isolated sessions
+- DuckDuckGo-first desktop browsing
+- Linux-first web app profiles
+- WhatsApp, GitHub, ChatGPT, Proton Mail, and similar apps in isolated sessions
 - clear privacy controls instead of hidden settings
+- encrypted local profile storage where the OS supports it
+- optional encrypted backup/sync direction
 - optional local-first AI assistance
 - no browser-vendor account requirement for basic usage
 - practical tools for builders, researchers, and power users
@@ -41,6 +74,7 @@ Zen Browser is not yet:
 - Electron `BrowserView` based Chromium rendering
 - tabs with persisted basic state
 - navigation controls
+- DuckDuckGo-first home search
 - split-screen tab view
 - custom app shell
 
@@ -50,15 +84,18 @@ Zen Browser is not yet:
 - isolated persistent partitions for launched apps
 - WhatsApp Web profile with Windows user-agent spoofing experiment for Linux calling support
 
-### Privacy controls
+### Privacy and encryption controls
 
 - simple ad/tracker host blocking
 - HTTPS upgrade attempt for HTTP URLs
 - optional user-agent spoofing
 - configurable history retention
 - local storage through Electron `safeStorage` when available
+- encryption status and encrypted backup/sync still need stronger implementation
 
 These controls are early. They should be treated as practical experiments, not strong privacy guarantees.
+
+See [`docs/encryption-plan.md`](docs/encryption-plan.md).
 
 ### AI panel
 
@@ -135,8 +172,23 @@ src/
   renderer/    React interface, views, panels, navigation, settings
 
 docs/
+  encryption-plan.md
+  real-browser-checklist.md
   rebuild-plan.md
 ```
+
+## Personal path policy
+
+Do not commit personal machine paths such as `/home/imran/...` or private local folder structures into the product UI, docs, defaults, or screenshots.
+
+Use generic paths only:
+
+```text
+~/.config/zen-browser
+/path/to/openclaw/docker-compose.yml
+```
+
+Local developer paths can exist in a private `.env` or ignored local config file, not in source-controlled product defaults.
 
 ## Known problems
 
@@ -151,6 +203,7 @@ These are not small issues. They are the reason the browser needs a rebuild path
 7. IPC actions need tighter validation as the browser grows.
 8. Packaging is not ready for normal users.
 9. The app needs a clean release mode that does not behave like a development build.
+10. Hard-coded local developer assumptions must be moved into user-configurable settings.
 
 ## Rebuild path
 
@@ -161,7 +214,7 @@ Use simple version names:
 - `v0.3 Web Apps` — isolated app profiles, permissions, reset controls
 - `v0.4 Privacy Controls` — maintained filters, allowlists, visible blocked counts, stable fingerprint profile
 - `v0.5 Local Assistant` — streaming, explicit context, provider settings, local/cloud warnings
-- `v0.6 Sync` — safe sync scope, conflict handling, manual export/import
+- `v0.6 Sync and Encryption` — safe sync scope, conflict handling, encrypted backup/import/export
 - `v0.7 Packaging` — AppImage, deb, icons, desktop entry
 - `v1.0 Daily Driver` — only after stability, packaging, tests, and privacy docs match behavior
 
@@ -175,6 +228,7 @@ Keep the project plain and professional.
 - Do not add fake privacy claims.
 - Do not add hidden telemetry.
 - Do not send page content to AI providers without explicit user action.
+- Do not commit personal laptop paths or local-only folder structures.
 - Prefer small verified patches over huge rewrites.
 - Keep names simple and readable.
 - Document every feature that touches user data.

--- a/docs/encryption-plan.md
+++ b/docs/encryption-plan.md
@@ -1,0 +1,127 @@
+# Encryption Plan
+
+Zen needs encryption because browsers store sensitive data: tabs, history, bookmarks, settings, sync metadata, app profile state, and eventually downloads or exports.
+
+Encryption must be real and explainable. It should protect user data without pretending to make the browser anonymous.
+
+## Current state
+
+The current storage layer uses Electron `safeStorage` when available. That is a good start because it lets the operating system protect encrypted data through the user's local keychain or secret service.
+
+Problem: if OS encryption is unavailable, the app can fall back to plaintext. That fallback must be visible to the user.
+
+## Encryption levels
+
+### Level 1: Local profile encryption
+
+Purpose: protect local Zen profile data at rest.
+
+Data covered:
+
+- settings
+- tabs
+- history
+- bookmarks once moved from renderer storage
+- sync metadata
+- app profile metadata
+
+Implementation direction:
+
+- keep using Electron `safeStorage` where available
+- expose encryption status in Privacy or Settings
+- warn clearly when encryption is unavailable
+- avoid storing secrets in plain JSON
+
+### Level 2: Backup export encryption
+
+Purpose: let the user export a backup safely.
+
+Data covered:
+
+- bookmarks
+- settings
+- tabs
+- selected history if user chooses
+
+Implementation direction:
+
+- export encrypted `.zenbackup` file
+- use a user passphrase
+- use modern authenticated encryption
+- include version metadata for future imports
+
+Recommended primitive:
+
+- Argon2id or scrypt for passphrase key derivation
+- XChaCha20-Poly1305 or AES-256-GCM for encryption
+
+Node support and package choice should be reviewed before implementation.
+
+### Level 3: Sync encryption
+
+Purpose: protect synced data before it leaves the machine.
+
+Data covered by default:
+
+- tabs
+- settings
+- bookmarks
+
+Data not synced by default:
+
+- cookies
+- passwords
+- session tokens
+- app login sessions
+
+Implementation direction:
+
+- encrypt sync payload before upload
+- store only encrypted blobs remotely
+- show last sync time
+- provide manual export/import fallback
+- handle conflicts instead of overwriting blindly
+
+### Level 4: Per-app profile protection
+
+Purpose: avoid mixing WhatsApp, GitHub, ChatGPT, Proton, and normal browsing state.
+
+Implementation direction:
+
+- each app gets a named isolated partition
+- each app shows stored data controls
+- user can clear one app without wiping the full browser
+- permissions are visible per app
+
+## User-facing encryption status
+
+Zen should show one of these states:
+
+```text
+Protected by OS encryption
+Local encryption unavailable: profile data may be stored as plaintext
+Backup encryption enabled
+Sync encryption enabled
+Sync encryption disabled
+```
+
+## Important rule
+
+Do not call anything bank-level, military-grade, prison-level, or unbreakable. That language makes the project look unserious.
+
+Use precise language:
+
+- encrypted at rest
+- encrypted before sync
+- protected by OS keychain
+- passphrase-protected export
+- not synced by default
+
+## First implementation tasks
+
+1. Add storage encryption status to the settings screen.
+2. Move bookmarks from renderer localStorage into main-process storage.
+3. Add manual encrypted export/import.
+4. Encrypt sync payload before upload.
+5. Add conflict handling for sync.
+6. Add tests for storage load/save, encrypted fallback, and corrupted file recovery.

--- a/docs/real-browser-checklist.md
+++ b/docs/real-browser-checklist.md
@@ -1,0 +1,182 @@
+# What Makes Zen a Real Browser
+
+A real browser is not just an app that opens websites. A real browser is a complete trust system around the web engine.
+
+Zen can become real, but it has to earn that label through reliability, security, and daily-use features.
+
+## Minimum real-browser requirements
+
+### 1. Rendering engine
+
+Zen uses Chromium through Electron. That means it can render modern sites, run JavaScript, play media, and load complex web apps.
+
+This is real browser capability, but it comes with Electron overhead and must be handled carefully.
+
+### 2. Navigation
+
+Required:
+
+- address bar
+- search bar
+- back, forward, reload
+- safe URL parsing
+- search fallback when text is not a URL
+- visible loading and error states
+- blocked-page screen for unsafe URLs
+
+### 3. Search identity
+
+Zen should be DuckDuckGo-first.
+
+Default:
+
+- DuckDuckGo as the main search engine
+- Startpage and Qwant as privacy alternatives
+- Google available only as a user-selected fallback
+
+The home page should visually make DuckDuckGo the main search path, not just one option in a row.
+
+### 4. Tabs and sessions
+
+Required:
+
+- create tab
+- close tab
+- restore tabs after restart
+- persist active tab
+- recover from crashed tabs
+- clean memory after close
+- avoid duplicate restored tabs
+- app tabs separated from normal browsing tabs
+
+### 5. Web app profiles
+
+This is where Zen can be useful quickly.
+
+Required app profiles:
+
+- WhatsApp
+- GitHub
+- ChatGPT
+- Proton Mail
+- Spotify or YouTube alternative
+
+Each app should have:
+
+- isolated storage partition
+- clear permission rules
+- reset session button
+- visible app identity
+- optional pinned status
+
+WhatsApp can be one of Zen's strongest reasons to exist on Linux, but it should be treated as an app profile, not the entire browser identity.
+
+### 6. Permissions
+
+A real browser must control access to:
+
+- camera
+- microphone
+- location
+- notifications
+- clipboard
+- downloads
+- external links
+
+Zen should never silently grant broad permissions. App profiles can have special rules, but those rules must be visible to the user.
+
+### 7. Downloads
+
+Required:
+
+- download prompt or default folder
+- progress state
+- cancel/retry
+- open downloaded file
+- show completed downloads
+- protect against suspicious file types with warnings
+
+### 8. History and bookmarks
+
+Required:
+
+- searchable history
+- clear history
+- configurable retention
+- bookmarks with folders
+- import/export bookmarks
+- local encrypted storage where available
+
+### 9. Privacy controls
+
+Required:
+
+- maintained filter lists or imported host lists
+- blocked request count
+- per-site allowlist
+- HTTPS upgrade with fallback
+- stable privacy profile instead of random user-agent per request
+- clear explanation of what each setting does and does not do
+
+Zen should never claim anonymity. Practical privacy is good. Fake privacy claims destroy trust.
+
+### 10. Encryption
+
+Encryption should protect local user data and synced data. It should not be marketing decoration.
+
+Required:
+
+- local profile encryption when OS keychain support exists
+- visible encryption status
+- warning when local encryption is unavailable
+- export backup encryption with user passphrase
+- optional sync encryption before upload
+- no syncing of cookies, passwords, or session tokens by default
+
+### 11. AI assistant
+
+Required:
+
+- explicit user action before page content is sent to any model
+- local gateway support
+- clear cloud-provider warning when cloud models are used
+- streaming responses
+- no hidden page scraping
+- no silent telemetry
+
+### 12. Updates and packaging
+
+Required:
+
+- AppImage or deb package
+- icon and desktop entry
+- release notes
+- update instructions
+- clean production build
+- no forced developer tools in release mode
+
+## What Zen should become first
+
+Zen should become a reliable Linux web-app browser before trying to become a full mainstream browser replacement.
+
+The first serious use case:
+
+> Open Zen, search privately with DuckDuckGo, run WhatsApp/GitHub/ChatGPT/Proton in clean isolated profiles, keep local data controlled, and optionally use a local AI assistant.
+
+That is useful. That is believable. That is buildable.
+
+## What must be removed from public-facing code/docs
+
+- personal machine paths
+- private folder structures
+- exaggerated privacy claims
+- fake blocked-count numbers
+- claims that imply full anonymity
+- hard-coded local developer assumptions
+
+Use generic paths only, such as:
+
+```text
+~/.config/zen-browser
+/path/to/openclaw/docker-compose.yml
+```

--- a/docs/rebuild-plan.md
+++ b/docs/rebuild-plan.md
@@ -1,0 +1,175 @@
+# Zen Browser Rebuild Plan
+
+Zen Browser should not try to compete with Chrome, Brave, Firefox, or Arc on day one. The first serious version should be a focused Linux-first browser shell for people who want controlled web apps, practical privacy controls, and a local AI assistant they understand.
+
+## What failed
+
+The first version failed because the README promised a mature privacy browser while the implementation is still a prototype. That mismatch hurts trust. A browser is a trust product before it is a UI product.
+
+Main problems:
+
+1. The privacy layer is too small.
+   The current ad and tracker blocker uses a short hard-coded list. That is useful for a demo but not enough for daily browsing.
+
+2. Fingerprint protection is oversold.
+   Randomizing the user agent per request can make a user more unique, not less unique. Fingerprint defense needs consistency per site/session and should not claim full anonymity.
+
+3. The product scope is too wide.
+   Browser, web-app launcher, WhatsApp spoofing, RSS reader, bookmarks, cloud sync, local AI, system dashboard, and future extensions are too much for an early codebase.
+
+4. The build system is not release-ready.
+   The project had development-mode webpack settings only, no verification script, no typecheck command, no tests, and no clear production build path.
+
+5. Security-critical actions need tighter boundaries.
+   Browser projects must treat IPC, local command execution, storage, sync, and permissions as dangerous surfaces.
+
+6. The documentation sounds more finished than the code.
+   The README should tell contributors what exists, what is experimental, and what still needs proof.
+
+## Product direction
+
+Position Zen Browser as:
+
+> A Linux-first desktop browser shell for controlled web apps, practical privacy, and local-first AI assistance.
+
+Do not position it as:
+
+- a Chrome replacement yet
+- a Firefox replacement
+- an anonymity browser
+- a hardened security browser
+- a finished privacy product
+
+## Version names
+
+Use plain version names. Avoid mythological, over-technical, or AI-generated sounding names.
+
+Recommended naming:
+
+- v0.1 Foundation
+- v0.2 Stable Tabs
+- v0.3 Web Apps
+- v0.4 Privacy Controls
+- v0.5 Local Assistant
+- v0.6 Sync
+- v0.7 Packaging
+- v1.0 Daily Driver
+
+## v0.1 Foundation
+
+Goal: make the repo honest, buildable, and easier to continue.
+
+Required:
+
+- clear README
+- production/development build split
+- typecheck script
+- verification script
+- remove forced devtools in production
+- remove unsafe default start flag
+- document known weak spots
+- create a small issue roadmap
+
+## v0.2 Stable Tabs
+
+Goal: make normal browsing reliable.
+
+Required:
+
+- stable tab restore
+- correct active tab persistence
+- crash recovery
+- loading/error states
+- navigation state updates
+- title/favicon handling
+- memory cleanup after closing tabs
+
+## v0.3 Web Apps
+
+Goal: make Zen useful even before it becomes a full browser.
+
+Required:
+
+- app profiles with isolated partitions
+- WhatsApp app profile
+- GitHub app profile
+- ChatGPT app profile
+- Proton Mail app profile
+- per-app permissions
+- visible session reset button per app
+
+## v0.4 Privacy Controls
+
+Goal: ship practical privacy without fake claims.
+
+Required:
+
+- use maintained filter lists or import compatible host lists
+- show blocked request count
+- per-site allowlist
+- consistent user agent mode instead of per-request random mode
+- HTTPS upgrade with fallback if the site breaks
+- storage encryption status warning
+- remove claims that are not implemented
+
+## v0.5 Local Assistant
+
+Goal: make the assistant useful but bounded.
+
+Required:
+
+- gateway status check
+- model/provider settings
+- streaming responses
+- current page summary through explicit user action
+- no hidden page scraping without user consent
+- clear warning when cloud providers are used
+
+## v0.6 Sync
+
+Goal: sync only what is safe and explainable.
+
+Required:
+
+- sync tabs/settings/bookmarks only
+- never sync cookies/passwords/session tokens by default
+- conflict handling
+- last synced timestamp
+- manual export/import fallback
+
+## v0.7 Packaging
+
+Goal: make it installable.
+
+Required:
+
+- AppImage build
+- .deb build
+- icon assets
+- desktop entry
+- update instructions
+- release checklist
+
+## v1.0 Daily Driver
+
+Only call it v1.0 when it can survive daily use.
+
+Required:
+
+- no critical startup crashes
+- reliable browsing
+- reliable app profiles
+- tested data wipe/export
+- basic automated tests
+- packaging works on a clean Ubuntu machine
+- privacy documentation matches behavior
+
+## Immediate next patches
+
+1. Fix main process development behavior.
+2. Move RSS fetching to the main process to remove third-party proxy dependency.
+3. Add a privacy status panel showing what is actually active.
+4. Add a history page.
+5. Add a download manager.
+6. Add test coverage for storage and URL filtering.
+7. Replace fingerprint randomization with stable browser profiles.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,27 @@
 {
   "name": "zen-browser",
-  "version": "1.0.0",
-  "description": "",
+  "version": "0.1.0",
+  "description": "A desktop browser experiment built with Electron, focused on practical privacy controls, Linux web-app compatibility, and local-first AI assistance.",
   "main": "dist/main/main.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "webpack --config webpack.config.js --watch",
-    "start": "electron . --no-sandbox",
-    "dev:start": "npm run build && npm run start"
+    "build:prod": "cross-env NODE_ENV=production webpack --config webpack.config.js",
+    "dev": "cross-env NODE_ENV=development webpack --config webpack.config.js --watch",
+    "start": "electron .",
+    "start:unsafe-no-sandbox": "electron . --no-sandbox",
+    "dev:start": "npm run build && npm run start",
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run typecheck && npm run build"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "electron",
+    "browser",
+    "privacy",
+    "linux",
+    "desktop-app"
+  ],
+  "author": "Imran Shiundu",
+  "license": "MIT",
   "devDependencies": {
     "@types/electron": "^1.4.38",
     "@types/node": "^25.2.0",

--- a/scripts/install-zen.sh
+++ b/scripts/install-zen.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME="Zen Browser"
+APP_ID="zen-browser"
+REPO_URL="${ZEN_REPO_URL:-https://github.com/imranshiundu/zen-browser.git}"
+BRANCH="${ZEN_BRANCH:-main}"
+INSTALL_DIR="${ZEN_INSTALL_DIR:-$HOME/.local/share/zen-browser}"
+BIN_DIR="$HOME/.local/bin"
+DESKTOP_DIR="$HOME/.local/share/applications"
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+LAUNCHER="$BIN_DIR/zen-browser"
+DESKTOP_FILE="$DESKTOP_DIR/zen-browser.desktop"
+UPDATE_SCRIPT="$INSTALL_DIR/scripts/update-zen.sh"
+SERVICE_FILE="$SYSTEMD_DIR/zen-browser-update.service"
+TIMER_FILE="$SYSTEMD_DIR/zen-browser-update.timer"
+
+info() { printf '\033[1;34m[Zen]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[Zen warning]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[Zen error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+need_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+ensure_linux_desktop() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    fail "This installer currently supports Linux desktop systems only."
+  fi
+}
+
+install_system_packages_hint() {
+  if command -v apt >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo apt update && sudo apt install -y git nodejs npm"
+  elif command -v dnf >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo dnf install -y git nodejs npm"
+  elif command -v pacman >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo pacman -S git nodejs npm"
+  fi
+}
+
+clone_or_update_repo() {
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+
+  if [[ -d "$INSTALL_DIR/.git" ]]; then
+    info "Existing installation found at $INSTALL_DIR"
+    git -C "$INSTALL_DIR" fetch origin "$BRANCH"
+    git -C "$INSTALL_DIR" checkout "$BRANCH"
+    git -C "$INSTALL_DIR" pull --ff-only origin "$BRANCH"
+  elif [[ -f "package.json" && -d ".git" ]]; then
+    info "Installing from current repository into $INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+    git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+  else
+    info "Cloning Zen Browser from $REPO_URL"
+    git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+  fi
+}
+
+build_app() {
+  info "Installing dependencies"
+  npm --prefix "$INSTALL_DIR" install
+
+  info "Building Zen Browser"
+  npm --prefix "$INSTALL_DIR" run build
+}
+
+write_launcher() {
+  mkdir -p "$BIN_DIR"
+  cat > "$LAUNCHER" <<EOF
+#!/usr/bin/env bash
+set -e
+cd "$INSTALL_DIR"
+exec npm start -- "\$@"
+EOF
+  chmod +x "$LAUNCHER"
+  info "Launcher installed at $LAUNCHER"
+}
+
+write_desktop_entry() {
+  mkdir -p "$DESKTOP_DIR"
+  cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Name=$APP_NAME
+Comment=DuckDuckGo-first Linux browser shell with isolated web apps
+Exec=$LAUNCHER
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+StartupNotify=true
+StartupWMClass=zen-browser
+Icon=web-browser
+Keywords=browser;web;duckduckgo;privacy;zen;
+EOF
+  chmod 644 "$DESKTOP_FILE"
+
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$DESKTOP_DIR" >/dev/null 2>&1 || true
+  fi
+
+  info "Desktop entry installed at $DESKTOP_FILE"
+}
+
+write_update_timer() {
+  mkdir -p "$SYSTEMD_DIR"
+
+  cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Update Zen Browser from GitHub
+Documentation=https://github.com/imranshiundu/zen-browser
+
+[Service]
+Type=oneshot
+Environment=ZEN_INSTALL_DIR=$INSTALL_DIR
+Environment=ZEN_BRANCH=$BRANCH
+ExecStart=$UPDATE_SCRIPT --quiet
+EOF
+
+  cat > "$TIMER_FILE" <<EOF
+[Unit]
+Description=Run Zen Browser update check every 7 days
+
+[Timer]
+OnBootSec=20min
+OnUnitActiveSec=7d
+Persistent=true
+Unit=zen-browser-update.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user daemon-reload || warn "Could not reload user systemd daemon. You may need to log out and back in."
+    systemctl --user enable --now zen-browser-update.timer || warn "Could not enable update timer automatically. Run: systemctl --user enable --now zen-browser-update.timer"
+    info "7-day update timer installed: zen-browser-update.timer"
+  else
+    warn "systemd user timers are unavailable. You can update manually with: $UPDATE_SCRIPT"
+  fi
+}
+
+main() {
+  ensure_linux_desktop
+  install_system_packages_hint
+  need_command git
+  need_command npm
+  need_command node
+
+  clone_or_update_repo
+  build_app
+  write_launcher
+  write_desktop_entry
+  write_update_timer
+
+  info "Installation complete. Start Zen Browser from your app launcher or run: zen-browser"
+}
+
+main "$@"

--- a/scripts/update-zen.sh
+++ b/scripts/update-zen.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+INSTALL_DIR="${ZEN_INSTALL_DIR:-$HOME/.local/share/zen-browser}"
+BRANCH="${ZEN_BRANCH:-main}"
+QUIET=0
+
+if [[ "${1:-}" == "--quiet" ]]; then
+  QUIET=1
+fi
+
+log() {
+  if [[ "$QUIET" -eq 0 ]]; then
+    printf '\033[1;34m[Zen update]\033[0m %s\n' "$*"
+  fi
+}
+
+warn() {
+  printf '\033[1;33m[Zen update warning]\033[0m %s\n' "$*" >&2
+}
+
+fail() {
+  printf '\033[1;31m[Zen update error]\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v npm >/dev/null 2>&1 || fail "npm is required"
+
+[[ -d "$INSTALL_DIR/.git" ]] || fail "Zen Browser is not installed at $INSTALL_DIR"
+
+cd "$INSTALL_DIR"
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+  log "Switching from $CURRENT_BRANCH to $BRANCH"
+  git checkout "$BRANCH"
+fi
+
+LOCAL_SHA="$(git rev-parse HEAD)"
+log "Checking for updates on origin/$BRANCH"
+git fetch origin "$BRANCH" --quiet
+REMOTE_SHA="$(git rev-parse "origin/$BRANCH")"
+
+if [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]]; then
+  log "Already up to date"
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA"; then
+  warn "Local installation has commits not on origin/$BRANCH. Update skipped to avoid overwriting local work."
+  exit 2
+fi
+
+log "Updating Zen Browser"
+git pull --ff-only origin "$BRANCH"
+
+log "Installing dependencies"
+npm install
+
+log "Building app"
+npm run build
+
+log "Update complete"

--- a/src/renderer/views/Home.css
+++ b/src/renderer/views/Home.css
@@ -6,20 +6,22 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background: radial-gradient(circle at center, rgba(10, 15, 13, 0.4) 0%, rgba(5, 7, 6, 1) 100%),
-        linear-gradient(135deg, rgba(46, 204, 113, 0.05) 0%, transparent 100%),
-        url('https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&q=80&w=2000');
-    background-size: cover;
-    background-position: center;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(222, 88, 51, 0.16), transparent 34%),
+        radial-gradient(circle at 80% 10%, rgba(46, 204, 113, 0.13), transparent 30%),
+        linear-gradient(145deg, #050706 0%, #07110d 48%, #030504 100%);
     overflow: hidden;
 }
 
-.home-overlay {
+.home-grid {
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at center, transparent 0%, rgba(0, 0, 0, 0.6) 100%);
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+    background-size: 44px 44px;
+    mask-image: radial-gradient(circle at center, black, transparent 72%);
     pointer-events: none;
-    z-index: 1;
 }
 
 .home-content {
@@ -27,19 +29,18 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-2xl);
-    padding: var(--spacing-xl);
+    gap: 24px;
+    padding: 32px;
     width: 100%;
-    max-width: 900px;
+    max-width: 980px;
     z-index: 2;
 }
 
-/* Privacy Badge */
-.privacy-badge {
-    background: var(--glass-bg);
+.product-pill {
+    background: rgba(255, 255, 255, 0.055);
     backdrop-filter: blur(var(--blur));
-    border: 1px solid var(--glass-border);
-    padding: 8px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    padding: 8px 14px;
     border-radius: var(--radius-full);
     display: flex;
     align-items: center;
@@ -47,65 +48,74 @@
     font-size: 10px;
     font-weight: 800;
     letter-spacing: 1.5px;
-    color: var(--text-muted);
+    color: rgba(248, 250, 252, 0.72);
 }
 
-.shield-green {
-    color: var(--accent-green);
-    filter: drop-shadow(0 0 5px var(--accent-green));
-}
-
-/* Clock Section */
-.clock-section {
+.hero-copy {
     text-align: center;
+    max-width: 820px;
 }
 
 .time {
-    font-size: 110px;
+    font-size: clamp(64px, 10vw, 116px);
     font-weight: 200;
-    letter-spacing: -6px;
+    letter-spacing: -7px;
     color: var(--text-primary);
-    margin-bottom: var(--spacing-xs);
-    opacity: 0.95;
-    line-height: 1;
+    line-height: 0.95;
+    opacity: 0.96;
 }
 
 .greeting {
-    font-size: 12px;
+    margin-top: 12px;
+    font-size: 11px;
     color: var(--text-secondary);
-    font-weight: 400;
-    letter-spacing: 5px;
+    font-weight: 700;
+    letter-spacing: 4px;
     text-transform: uppercase;
-    opacity: 0.6;
+    opacity: 0.7;
 }
 
-/* Search Stack */
+.hero-copy h1 {
+    margin: 18px auto 0;
+    font-size: clamp(30px, 4.6vw, 58px);
+    line-height: 0.98;
+    letter-spacing: -2.4px;
+    max-width: 840px;
+}
+
+.hero-subtitle {
+    max-width: 690px;
+    margin: 18px auto 0;
+    color: var(--text-secondary);
+    font-size: 15px;
+    line-height: 1.7;
+}
+
 .search-stack {
     width: 100%;
-    max-width: 650px;
+    max-width: 720px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 16px;
+    gap: 14px;
 }
 
 .search-container {
     width: 100%;
     display: flex;
     align-items: center;
-    background: var(--glass-bg);
+    background: rgba(8, 13, 10, 0.76);
     backdrop-filter: blur(var(--blur));
-    border: 1px solid var(--glass-border);
-    border-radius: var(--radius-xl);
-    padding: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 24px;
+    padding: 7px;
     transition: all var(--transition-normal);
-    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.48);
 }
 
 .search-container:focus-within {
-    border-color: var(--accent-green);
-    background: rgba(13, 19, 16, 0.9);
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5), var(--shadow-glow);
+    border-color: rgba(222, 88, 51, 0.9);
+    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.55), 0 0 42px rgba(222, 88, 51, 0.16);
     transform: translateY(-2px);
 }
 
@@ -115,16 +125,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--text-muted);
-    background: var(--bg-tertiary);
-    border-radius: var(--radius-lg);
+    color: #de5833;
+    background: rgba(222, 88, 51, 0.12);
+    border-radius: 18px;
     margin-right: 12px;
     transition: all var(--transition-fast);
-}
-
-.search-container:focus-within .search-engine-preview {
-    color: var(--accent-green);
-    background: var(--accent-green-dim);
 }
 
 .search-input {
@@ -135,16 +140,20 @@
     color: var(--text-primary);
     font-size: 16px;
     font-family: var(--font-family);
-    padding: 12px 0;
+    padding: 13px 0;
+}
+
+.search-input::placeholder {
+    color: rgba(148, 163, 184, 0.7);
 }
 
 .search-submit {
-    background: var(--bg-tertiary);
+    background: #de5833;
     border: none;
-    color: var(--text-muted);
-    width: 44px;
-    height: 44px;
-    border-radius: var(--radius-lg);
+    color: #fff;
+    width: 46px;
+    height: 46px;
+    border-radius: 17px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -153,32 +162,33 @@
 }
 
 .search-submit:hover {
-    background: var(--accent-green);
-    color: var(--bg-primary);
+    transform: scale(1.04);
+    filter: brightness(1.08);
 }
 
-/* Engine Selectors */
 .engine-selectors {
     display: flex;
-    gap: 12px;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .engine-selectors button {
-    background: transparent;
-    border: 1px solid var(--glass-border);
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     color: var(--text-muted);
-    padding: 4px 12px;
+    padding: 7px 12px;
     border-radius: var(--radius-full);
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 800;
-    letter-spacing: 1px;
+    letter-spacing: 0.8px;
     cursor: pointer;
     transition: all var(--transition-fast);
 }
 
 .engine-selectors button:hover {
     color: var(--text-primary);
-    border-color: var(--text-muted);
+    border-color: rgba(255, 255, 255, 0.2);
 }
 
 .engine-selectors button.active {
@@ -187,18 +197,53 @@
     border-color: var(--text-primary);
 }
 
-/* Speed Dial */
+.engine-selectors button.primary-engine.active {
+    background: #de5833;
+    color: #fff;
+    border-color: #de5833;
+}
+
+.fallback-engine {
+    opacity: 0.68;
+}
+
+.trust-strip {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.trust-strip div {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.075);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.trust-strip svg {
+    color: var(--accent-green);
+}
+
 .speed-dial {
     display: flex;
-    gap: 48px;
-    margin-top: 24px;
+    gap: 26px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .speed-dial-item {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     background: transparent;
     border: none;
     cursor: pointer;
@@ -206,12 +251,12 @@
 }
 
 .speed-dial-icon {
-    width: 64px;
-    height: 64px;
+    width: 58px;
+    height: 58px;
     border-radius: 20px;
-    background: var(--glass-bg);
+    background: rgba(255, 255, 255, 0.045);
     backdrop-filter: blur(var(--blur));
-    border: 1px solid var(--glass-border);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -220,18 +265,18 @@
 }
 
 .speed-dial-item:hover .speed-dial-icon {
-    transform: translateY(-8px) scale(1.1);
-    background: var(--bg-tertiary);
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    transform: translateY(-6px);
+    background: rgba(222, 88, 51, 0.11);
+    border-color: rgba(222, 88, 51, 0.6);
+    color: #de5833;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.42);
 }
 
 .speed-dial-label {
     font-size: 10px;
-    font-weight: 700;
+    font-weight: 800;
     color: var(--text-muted);
-    letter-spacing: 1.5px;
+    letter-spacing: 1.4px;
     text-transform: uppercase;
     transition: color var(--transition-fast);
 }
@@ -240,45 +285,32 @@
     color: var(--text-primary);
 }
 
-/* Home Footer */
 .home-footer {
     position: absolute;
-    bottom: 32px;
-    left: 40px;
-    right: 40px;
+    bottom: 24px;
+    left: 36px;
+    right: 36px;
     display: flex;
     justify-content: space-between;
     align-items: center;
     z-index: 10;
-}
-
-.wallpaper-credit {
-    font-size: 9px;
-    color: var(--text-muted);
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.focus-mode-btn {
-    background: var(--glass-bg);
-    backdrop-filter: blur(var(--blur));
-    border: 1px solid var(--glass-border);
-    color: var(--text-secondary);
-    padding: 10px 24px;
-    border-radius: var(--radius-full);
     font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 2px;
-    cursor: pointer;
-    transition: all var(--transition-normal);
+    color: rgba(148, 163, 184, 0.74);
+    letter-spacing: 1px;
+    text-transform: uppercase;
 }
 
-.focus-mode-btn:hover {
-    background: var(--accent-green-dim);
-    border-color: var(--accent-green);
-    color: var(--accent-green);
-    transform: scale(1.05);
+@media (max-width: 760px) {
+    .home-content {
+        padding: 24px;
+        gap: 18px;
+    }
+
+    .hero-copy h1 {
+        letter-spacing: -1.4px;
+    }
+
+    .home-footer {
+        display: none;
+    }
 }

--- a/src/renderer/views/Home.tsx
+++ b/src/renderer/views/Home.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './Home.css';
-import { Search, Mic, Lock, Github, MessageSquare, Mail, Video, Newspaper, Mountain, Shield } from 'lucide-react';
+import { Search, Lock, Github, MessageSquare, Mail, Video, Newspaper, Shield, Globe2, KeyRound } from 'lucide-react';
 
 const Home: React.FC = () => {
     const [time, setTime] = useState(new Date());
@@ -19,13 +19,11 @@ const Home: React.FC = () => {
         let url = '';
         const query = searchQuery.trim();
 
-        // Check if it's a URL
         if (query.match(/^https?:\/\//)) {
             url = query;
         } else if (query.includes('.') && !query.includes(' ')) {
             url = 'https://' + query;
         } else {
-            // Search query
             switch (activeEngine) {
                 case 'duckduckgo':
                     url = `https://duckduckgo.com/?q=${encodeURIComponent(query)}`;
@@ -41,7 +39,6 @@ const Home: React.FC = () => {
             }
         }
 
-        // Navigate to browser view with the URL
         if (window.electronAPI?.navigateTo) {
             window.electronAPI.navigateTo(url);
         }
@@ -55,11 +52,11 @@ const Home: React.FC = () => {
     };
 
     const speedDialLinks = [
-        { icon: MessageSquare, label: 'Reddit', url: 'https://reddit.com', color: '#FF4500' },
-        { icon: Github, label: 'GitHub', url: 'https://github.com', color: '#6cc644' },
-        { icon: Mail, label: 'Proton', url: 'https://proton.me', color: '#6d4aff' },
-        { icon: Video, label: 'Invidious', url: 'https://invidious.io', color: '#ff0000' },
-        { icon: Newspaper, label: 'News', url: 'https://news.ycombinator.com', color: '#ff6600' },
+        { icon: MessageSquare, label: 'WhatsApp', url: 'https://web.whatsapp.com' },
+        { icon: Github, label: 'GitHub', url: 'https://github.com' },
+        { icon: Mail, label: 'Proton', url: 'https://mail.proton.me' },
+        { icon: Video, label: 'Invidious', url: 'https://invidious.io' },
+        { icon: Newspaper, label: 'News', url: 'https://news.ycombinator.com' },
     ];
 
     const handleSpeedDialClick = (url: string) => {
@@ -70,30 +67,31 @@ const Home: React.FC = () => {
 
     const getEngineIcon = () => {
         switch (activeEngine) {
-            case 'duckduckgo': return <Lock size={18} />;
-            case 'startpage': return <Search size={18} />;
-            case 'qwant': return <Search size={18} />;
+            case 'duckduckgo': return <Shield size={18} />;
+            case 'startpage': return <Lock size={18} />;
+            case 'qwant': return <Globe2 size={18} />;
             default: return <Search size={18} />;
         }
     };
 
     return (
         <div className="home-container">
-            <div className="home-overlay"></div>
+            <div className="home-grid" />
             <div className="home-content animate-fade-in">
-                {/* Privacy Badge */}
-                <div className="privacy-badge">
-                    <Shield size={14} className="shield-green" />
-                    <span>2.4K TRACKERS SHIELDED</span>
+                <div className="product-pill">
+                    <Shield size={14} />
+                    <span>DUCKDUCKGO-FIRST · LOCAL PROFILE · WEB APP READY</span>
                 </div>
 
-                {/* Clock & Greeting */}
-                <div className="clock-section">
+                <section className="hero-copy">
                     <div className="time">{time.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}</div>
-                    <div className="greeting">{getGreeting()}, Zen User</div>
-                </div>
+                    <p className="greeting">{getGreeting()}, Zen User</p>
+                    <h1>Browse clean. Keep apps separate. Search with DuckDuckGo.</h1>
+                    <p className="hero-subtitle">
+                        A Linux-first browser shell for private search, isolated web apps, practical shields, and encrypted local profile storage where your OS supports it.
+                    </p>
+                </section>
 
-                {/* Search Bar */}
                 <div className="search-stack">
                     <form onSubmit={handleSearch} className="search-container">
                         <div className="search-engine-preview">
@@ -101,50 +99,37 @@ const Home: React.FC = () => {
                         </div>
                         <input
                             type="text"
-                            placeholder={`Search ${activeEngine.charAt(0).toUpperCase() + activeEngine.slice(1)} privately...`}
+                            placeholder="Search DuckDuckGo or enter a URL"
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
                             className="search-input"
+                            autoFocus
                         />
-                        <button type="submit" className="search-submit">
+                        <button type="submit" className="search-submit" aria-label="Search or navigate">
                             <Search size={18} />
                         </button>
                     </form>
 
-                    {/* Quick Search Engines */}
-                    <div className="engine-selectors">
-                        <button
-                            className={activeEngine === 'duckduckgo' ? 'active' : ''}
-                            onClick={() => setActiveEngine('duckduckgo')}
-                        >DDG</button>
-                        <button
-                            className={activeEngine === 'startpage' ? 'active' : ''}
-                            onClick={() => setActiveEngine('startpage')}
-                        >SP</button>
-                        <button
-                            className={activeEngine === 'qwant' ? 'active' : ''}
-                            onClick={() => setActiveEngine('qwant')}
-                        >QT</button>
-                        <button
-                            className={activeEngine === 'google' ? 'active' : ''}
-                            onClick={() => setActiveEngine('google')}
-                        >G</button>
+                    <div className="engine-selectors" aria-label="Search engine selector">
+                        <button className={activeEngine === 'duckduckgo' ? 'active primary-engine' : ''} onClick={() => setActiveEngine('duckduckgo')}>DuckDuckGo</button>
+                        <button className={activeEngine === 'startpage' ? 'active' : ''} onClick={() => setActiveEngine('startpage')}>Startpage</button>
+                        <button className={activeEngine === 'qwant' ? 'active' : ''} onClick={() => setActiveEngine('qwant')}>Qwant</button>
+                        <button className={activeEngine === 'google' ? 'active fallback-engine' : 'fallback-engine'} onClick={() => setActiveEngine('google')}>Google fallback</button>
                     </div>
                 </div>
 
-                {/* Speed Dial */}
+                <div className="trust-strip">
+                    <div><Shield size={16} /><span>Practical shields</span></div>
+                    <div><KeyRound size={16} /><span>Encryption-aware storage</span></div>
+                    <div><MessageSquare size={16} /><span>WhatsApp profile</span></div>
+                </div>
+
                 <div className="speed-dial">
-                    {speedDialLinks.map((link, index) => {
+                    {speedDialLinks.map((link) => {
                         const IconComponent = link.icon;
                         return (
-                            <button
-                                key={index}
-                                onClick={() => handleSpeedDialClick(link.url)}
-                                className="speed-dial-item"
-                            >
-                                <div className="speed-dial-icon">
-                                    <IconComponent size={24} />
-                                </div>
+                            <button key={link.label} onClick={() => handleSpeedDialClick(link.url)} className="speed-dial-item">
+                                <div className="speed-dial-icon"><IconComponent size={22} /></div>
                                 <span className="speed-dial-label">{link.label}</span>
                             </button>
                         );
@@ -152,16 +137,9 @@ const Home: React.FC = () => {
                 </div>
             </div>
 
-            {/* Footer */}
             <div className="home-footer">
-                <div className="wallpaper-credit">
-                    <Mountain size={16} className="credit-icon" />
-                    Misty Forest
-                </div>
-                <button className="focus-mode-btn">
-                    <Mountain size={16} className="focus-icon" />
-                    FOCUS MODE
-                </button>
+                <span>Zen Browser Foundation</span>
+                <span>Daily-driver status: prototype, hardening in progress</span>
             </div>
         </div>
     );

--- a/src/renderer/views/PrivacyView.css
+++ b/src/renderer/views/PrivacyView.css
@@ -3,8 +3,11 @@
     flex-direction: column;
     height: 100%;
     overflow-y: auto;
-    padding: 28px 32px;
-    background: var(--bg-primary);
+    padding: 30px 34px;
+    background:
+        radial-gradient(circle at 10% 0%, rgba(222, 88, 51, 0.09), transparent 28%),
+        radial-gradient(circle at 90% 0%, rgba(34, 197, 94, 0.08), transparent 30%),
+        var(--bg-primary);
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
 }
@@ -13,67 +16,107 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 32px;
+    margin-bottom: 24px;
     text-align: center;
 }
 
 .shield-container {
     position: relative;
-    margin-bottom: 16px;
+    margin-bottom: 14px;
 }
 
 .giant-shield {
-    color: var(--accent-green);
-    filter: drop-shadow(0 0 30px rgba(34, 197, 94, 0.3));
+    color: #de5833;
+    filter: drop-shadow(0 0 34px rgba(222, 88, 51, 0.28));
 }
 
 .shield-glow {
     position: absolute;
-    inset: -20px;
-    background: radial-gradient(circle, rgba(34, 197, 94, 0.1) 0%, transparent 70%);
+    inset: -22px;
+    background: radial-gradient(circle, rgba(222, 88, 51, 0.12) 0%, transparent 70%);
     border-radius: 50%;
     pointer-events: none;
 }
 
+.eyebrow {
+    margin: 0 0 8px;
+    font-size: 10px;
+    color: var(--text-muted);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    font-weight: 800;
+}
+
 .privacy-title {
-    font-size: 24px;
-    font-weight: 700;
+    max-width: 680px;
+    font-size: clamp(28px, 4vw, 48px);
+    line-height: 1;
+    letter-spacing: -1.8px;
+    font-weight: 750;
     color: var(--text-primary);
-    margin: 0 0 6px;
+    margin: 0 0 12px;
 }
 
 .privacy-description {
     font-size: 14px;
     color: var(--text-secondary);
-    margin: 0 0 12px;
+    margin: 0 0 14px;
 }
 
 .saved-badge {
     color: #4ade80;
-    font-weight: 600;
+    font-weight: 700;
+}
+
+.status-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .security-badge {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 16px;
+    padding: 7px 14px;
     border-radius: 20px;
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.5px;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.7px;
     background: rgba(34, 197, 94, 0.1);
-    border: 1px solid rgba(34, 197, 94, 0.3);
+    border: 1px solid rgba(34, 197, 94, 0.26);
     color: #4ade80;
 }
 
 .security-badge.partial {
     background: rgba(245, 158, 11, 0.1);
-    border-color: rgba(245, 158, 11, 0.3);
+    border-color: rgba(245, 158, 11, 0.28);
     color: #fbbf24;
 }
 
+.encryption-card {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    max-width: 960px;
+    width: 100%;
+    margin: 0 auto 14px;
+    padding: 18px;
+    border-radius: 18px;
+    background: rgba(222, 88, 51, 0.08);
+    border: 1px solid rgba(222, 88, 51, 0.18);
+}
+
+.encryption-icon {
+    color: #de5833;
+    background: rgba(222, 88, 51, 0.1);
+}
+
 .privacy-modules {
+    max-width: 960px;
+    width: 100%;
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -84,22 +127,33 @@
     align-items: flex-start;
     gap: 16px;
     padding: 16px 18px;
-    border-radius: 14px;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    background: rgba(255, 255, 255, 0.03);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.035);
     transition: all 0.2s;
 }
 
+.privacy-module:hover {
+    background: rgba(255, 255, 255, 0.055);
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
 .privacy-module.on {
-    border-color: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.13);
 }
 
 .privacy-module.off {
-    opacity: 0.7;
+    opacity: 0.72;
 }
 
 .mod-icon {
-    margin-top: 2px;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.045);
     flex-shrink: 0;
 }
 
@@ -110,21 +164,22 @@
 .mod-title-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 10px;
     margin-bottom: 5px;
 }
 
 .mod-title {
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 700;
     color: var(--text-primary);
 }
 
 .mod-status {
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    padding: 2px 8px;
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.7px;
+    padding: 3px 8px;
     border-radius: 10px;
 }
 
@@ -134,7 +189,7 @@
 }
 
 .mod-status.inactive {
-    background: rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.06);
     color: var(--text-secondary);
 }
 
@@ -142,17 +197,16 @@
     font-size: 12px;
     color: var(--text-secondary);
     margin: 0;
-    line-height: 1.5;
+    line-height: 1.55;
 }
 
-/* Toggle */
 .toggle-switch {
     position: relative;
     display: inline-block;
     width: 44px;
     height: 24px;
     flex-shrink: 0;
-    margin-top: 2px;
+    margin-top: 8px;
 }
 
 .toggle-switch input {
@@ -195,8 +249,8 @@
 .retention-select {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 8px;
-    padding: 6px 10px;
+    border-radius: 10px;
+    padding: 8px 10px;
     color: var(--text-primary);
     font-size: 13px;
     cursor: pointer;
@@ -206,4 +260,21 @@
 
 .retention-select option {
     background: #1a1a1e;
+}
+
+.privacy-note {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+    border-radius: 16px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.privacy-note svg {
+    color: #de5833;
+    flex-shrink: 0;
 }

--- a/src/renderer/views/PrivacyView.tsx
+++ b/src/renderer/views/PrivacyView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './PrivacyView.css';
-import { Shield, Lock, EyeOff, Fingerprint, Activity, CheckCircle2, XCircle, Zap } from 'lucide-react';
+import { Shield, Lock, EyeOff, Fingerprint, Activity, CheckCircle2, AlertTriangle, Zap, KeyRound, Database } from 'lucide-react';
 
 interface PrivacySettings {
     adShield: boolean;
@@ -46,35 +46,35 @@ const PrivacyView: React.FC = () => {
             key: 'adShield' as keyof PrivacySettings,
             icon: Shield,
             title: 'Ad & Tracker Shield',
-            description: 'Blocks ads, analytics trackers, and cross-site data collectors at the network level before they load. Uses a curated host blocklist updated regularly.',
+            description: 'Blocks known ad and tracker hosts before they load. Current implementation is useful but still needs maintained filter-list support.',
             color: '#22c55e'
         },
         {
             key: 'fingerprintCloak' as keyof PrivacySettings,
             icon: Fingerprint,
-            title: 'Fingerprint Cloak',
-            description: 'Randomizes your browser fingerprint on every request — User-Agent, platform, renderer info — so advertising networks cannot build a profile of you.',
+            title: 'Fingerprint Profile',
+            description: 'Experimental identity masking. This must evolve into stable per-profile fingerprints; random per-request identities are not a finished privacy design.',
             color: '#3b82f6'
         },
         {
             key: 'forceHttps' as keyof PrivacySettings,
             icon: Lock,
-            title: 'Force HTTPS',
-            description: 'Automatically upgrades all HTTP requests to HTTPS. If a site does not support HTTPS, it will fail rather than send your data in cleartext.',
+            title: 'HTTPS Upgrade',
+            description: 'Attempts to upgrade insecure HTTP navigation to HTTPS where available. Some sites may still need fallback handling.',
             color: '#a855f7'
         },
         {
             key: 'scriptFortress' as keyof PrivacySettings,
             icon: Activity,
             title: 'Script Fortress',
-            description: 'Blocks inline and third-party JavaScript from executing. This is a strong protection against malicious scripts and zero-day browser exploits. Warning: may break some sites.',
+            description: 'Future strict mode for blocking risky scripts. Kept off by default because aggressive script blocking can break normal websites.',
             color: '#f59e0b'
         },
         {
             key: 'deepSpoof' as keyof PrivacySettings,
             icon: Zap,
-            title: 'WhatsApp Windows Spoof',
-            description: 'Convinces WhatsApp Web that you are on Windows by overriding the User-Agent and navigator.platform on whatsapp.com. This unlocks video calls and voice calls for Linux users.',
+            title: 'WhatsApp Linux Compatibility',
+            description: 'Experimental WhatsApp Web profile behavior for Linux users. This is a compatibility feature, not a privacy shield.',
             color: '#25d366'
         },
     ];
@@ -85,19 +85,31 @@ const PrivacyView: React.FC = () => {
         <div className="privacy-view">
             <div className="privacy-hero">
                 <div className="shield-container">
-                    <Shield size={80} className="giant-shield" />
+                    <Shield size={72} className="giant-shield" />
                     <div className="shield-glow" />
                 </div>
-                <h1 className="privacy-title">Privacy Control Centre</h1>
+                <p className="eyebrow">Privacy and encryption control</p>
+                <h1 className="privacy-title">Know exactly what Zen is protecting.</h1>
                 <p className="privacy-description">
-                    {activeCount} of {modules.length} shields active.
+                    {activeCount} of {modules.length} browser controls active.
                     {saved && <span className="saved-badge"> Saved.</span>}
                 </p>
-                <div className={`security-badge ${activeCount === modules.length ? '' : 'partial'}`}>
-                    {activeCount === modules.length
-                        ? <><CheckCircle2 size={14} /> FULLY HARDENED</>
-                        : <><XCircle size={14} /> PARTIAL PROTECTION</>
-                    }
+                <div className="status-row">
+                    <div className="security-badge partial"><AlertTriangle size={14} /> PROTOTYPE SHIELDS</div>
+                    <div className="security-badge"><CheckCircle2 size={14} /> DUCKDUCKGO-FIRST</div>
+                </div>
+            </div>
+
+            <div className="encryption-card">
+                <div className="mod-icon encryption-icon"><KeyRound size={24} /></div>
+                <div>
+                    <div className="mod-title-row">
+                        <span className="mod-title">Local profile encryption</span>
+                        <span className="mod-status active">OS-PROTECTED WHEN AVAILABLE</span>
+                    </div>
+                    <p className="mod-description">
+                        Zen uses Electron safeStorage for local profile data when the operating system exposes encryption. Next step: show live encryption availability and add passphrase-protected backup export.
+                    </p>
                 </div>
             </div>
 
@@ -117,25 +129,21 @@ const PrivacyView: React.FC = () => {
                             <p className="mod-description">{mod.description}</p>
                         </div>
                         <label className="toggle-switch">
-                            <input
-                                type="checkbox"
-                                checked={!!settings[mod.key]}
-                                onChange={() => toggle(mod.key)}
-                            />
+                            <input type="checkbox" checked={!!settings[mod.key]} onChange={() => toggle(mod.key)} />
                             <span className="toggle-slider" />
                         </label>
                     </div>
                 ))}
 
                 <div className="privacy-module retention-module">
-                    <div className="mod-icon" style={{ color: '#64748b' }}>
-                        <EyeOff size={22} />
+                    <div className="mod-icon" style={{ color: '#94a3b8' }}>
+                        <Database size={22} />
                     </div>
                     <div className="mod-info">
                         <div className="mod-title-row">
                             <span className="mod-title">History Retention</span>
                         </div>
-                        <p className="mod-description">How long browsing history is stored locally. "Forever" keeps it until you wipe manually.</p>
+                        <p className="mod-description">How long browsing history is stored locally. Use shorter retention for a cleaner profile.</p>
                     </div>
                     <select
                         className="retention-select"
@@ -150,6 +158,11 @@ const PrivacyView: React.FC = () => {
                         <option value="7d">7 days</option>
                         <option value="1d">24 hours</option>
                     </select>
+                </div>
+
+                <div className="privacy-note">
+                    <EyeOff size={16} />
+                    <span>Zen should describe protection precisely. No fake anonymity claims, no inflated tracker counts, no hidden page sharing.</span>
                 </div>
             </div>
         </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,23 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const baseTsRule = {
+    test: /\.tsx?$/,
+    use: 'ts-loader',
+    exclude: /node_modules/,
+};
 
 module.exports = [
-    // Main Process Configuration
     {
-        mode: 'development',
+        name: 'main',
+        mode: isProduction ? 'production' : 'development',
         entry: './src/main/main.ts',
         target: 'electron-main',
+        devtool: isProduction ? false : 'source-map',
         module: {
-            rules: [
-                {
-                    test: /\.ts$/,
-                    use: 'ts-loader',
-                    exclude: /node_modules/,
-                },
-            ],
+            rules: [baseTsRule],
         },
         resolve: {
             extensions: ['.ts', '.js'],
@@ -25,20 +27,14 @@ module.exports = [
             filename: 'main.js',
         },
     },
-
-    // Preload Process Configuration
     {
-        mode: 'development',
+        name: 'preload',
+        mode: isProduction ? 'production' : 'development',
         entry: './src/preload/preload.ts',
         target: 'electron-preload',
+        devtool: isProduction ? false : 'source-map',
         module: {
-            rules: [
-                {
-                    test: /\.ts$/,
-                    use: 'ts-loader',
-                    exclude: /node_modules/,
-                },
-            ],
+            rules: [baseTsRule],
         },
         resolve: {
             extensions: ['.ts', '.js'],
@@ -48,20 +44,15 @@ module.exports = [
             filename: 'preload.js',
         },
     },
-
-    // Renderer Process Configuration
     {
-        mode: 'development',
+        name: 'renderer',
+        mode: isProduction ? 'production' : 'development',
         entry: './src/renderer/renderer.tsx',
         target: 'electron-renderer',
-        devtool: 'source-map',
+        devtool: isProduction ? false : 'source-map',
         module: {
             rules: [
-                {
-                    test: /\.(ts|tsx)$/,
-                    use: 'ts-loader',
-                    exclude: /node_modules/,
-                },
+                baseTsRule,
                 {
                     test: /\.css$/,
                     use: ['style-loader', 'css-loader'],


### PR DESCRIPTION
## Summary

This PR adds the first practical Linux install/update path for Zen Browser.

Added:
- `scripts/install-zen.sh`
- `scripts/update-zen.sh`

The installer:
- installs Zen into the user's local app space
- installs dependencies
- builds the Electron app
- creates a `zen-browser` launcher
- creates a Linux desktop entry so Zen appears in the app launcher
- creates a user-level systemd timer that checks for updates every 7 days

The updater:
- checks GitHub for changes
- only fast-forwards clean installs
- skips updates if the local install has unpushed/local commits
- installs dependencies after update
- rebuilds the app

## Why

Before Zen can be a real browser, users need a real install path. This is not final packaging, but it gives Linux users a way to install, launch, and receive updates while we continue toward AppImage/deb releases.

## Design decision

I used a user-level systemd timer instead of a hidden always-running background process. That is safer and more transparent: users can inspect it, disable it, or run updates manually.

## Next goal: make Zen a real browser

After this installer step, the next work should focus on core browser fundamentals:

1. download manager
2. permission prompts for camera, mic, notifications, location, and clipboard
3. stable tab/session restore
4. crash recovery
5. maintained privacy filter lists
6. encryption status exposed in UI
7. packaged AppImage/deb builds
