### PR TITLE
Apply Hoo branding to installed UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,76 @@
-# Zen Browser
+<p align="center">
+  <img src="./docs/branding/hoo-branding.svg" alt="Hoo Browser" width="920" />
+</p>
 
-Zen Browser is an experimental desktop browser shell built with Electron. The goal is to shape it into a Linux-first browser for controlled web apps, DuckDuckGo-first search, practical privacy controls, encrypted local data where possible, and local-first AI assistance.
+<p align="center">
+  <strong>OWL-GUIDED. PRIVACY-FIRST. WEB FREEDOM.</strong>
+</p>
 
-This is not a finished Chrome, Brave, Firefox, or Arc replacement yet. It is a prototype that needs hardening before anyone should trust it as a daily driver.
+<p align="center">
+  Hoo Browser is a DuckDuckGo-first desktop browser focused on practical privacy,
+  isolated web apps, and a calm, watchful browsing experience for Linux and beyond.
+</p>
+
+---
+
+# Hoo Browser
+
+Hoo Browser is an experimental desktop browser shell built with Electron. The goal is to shape it into a real installable Linux-first browser for DuckDuckGo-first search, isolated web apps, practical privacy controls, encryption-aware local data, and optional local-first AI assistance.
+
+Hoo is not just a renamed Zen. The product direction is now owl-guided: the browser should feel watchful, calm, useful, protective, and honest about what it can and cannot do.
+
+This is still not a finished Chrome, Brave, Firefox, or Arc replacement. It can render web pages through Electron's Chromium engine, but the project still needs stronger downloads, visible permission prompts, crash recovery, tests, maintained privacy filters, and packaging verification before it should be trusted as a daily driver.
+
+## Brand system
+
+### Name
+
+**Hoo Browser**
+
+### Tagline
+
+**OWL-GUIDED. PRIVACY-FIRST. WEB FREEDOM.**
+
+### Colors
+
+- **Hoo Orange** — `#FF6A00`
+- **Leaf Green** — `#3DBB78`
+- **Feather Cream** — `#F2F2EF`
+- **Forest Black** — `#0E1111`
+- **Slate Charcoal** — `#171B1D`
+
+### Mascot direction
+
+Hoo is the watchful owl guide. The mascot is not decoration. It should appear in the app icon, new-tab identity, privacy moments, settings, empty states, and protection prompts. The tone should be friendly and useful, not childish.
+
+Brand assets live in:
+
+```text
+src/renderer/assets/branding/
+docs/branding/
+```
 
 ## Current status
 
-Version: `v0.1 Foundation`
+Version: `v0.2 Hoo Foundation`
 
-The current codebase can render web pages through Electron's Chromium engine and includes early versions of tabs, app profiles, privacy toggles, bookmarks, RSS, MEGA sync, and an OpenClaw AI panel.
+The current codebase includes early versions of:
 
-The important work now is to make the project honest, stable, testable, and easier to improve.
+- Chromium rendering through Electron `BrowserView`
+- tabs with persisted basic state
+- navigation controls
+- DuckDuckGo-first home search
+- isolated web-app profiles
+- WhatsApp Web profile experiment for Linux
+- privacy toggles
+- bookmarks
+- RSS
+- MEGA sync experiment
+- OpenClaw AI panel
+- Linux install/update scripts
+- Hoo branded home UI and README identity
+
+The important work now is to make the project stable, testable, installable, and honest.
 
 ## What makes a real browser real?
 
@@ -28,44 +88,19 @@ A real browser is not just an app that opens a website. A real browser needs:
 - update/install packaging
 - clear privacy behavior that matches the code
 
-Zen already has the beginning of the rendering, navigation, tabs, app profiles, bookmarks, and privacy layers. It still needs stronger downloads, permissions UI, crash recovery, tests, packaging, and privacy hardening before it can be called a daily-driver browser.
+Hoo already has the beginning of rendering, navigation, tabs, app profiles, bookmarks, and privacy layers. It still needs stronger downloads, permissions UI, crash recovery, tests, packaging, and privacy hardening before it can be called daily-driver ready.
 
 See [`docs/real-browser-checklist.md`](docs/real-browser-checklist.md).
 
 ## Product identity
 
-Zen should become useful first as:
+Hoo should become useful first as:
 
-> A Linux-first browser for DuckDuckGo search, isolated web apps, practical privacy controls, encrypted local profile data where available, and optional local AI help.
+> A DuckDuckGo-first desktop browser for isolated web apps, practical privacy controls, encryption-aware local profile data, and a calm owl-guided browsing experience.
 
 DuckDuckGo is the default search identity. Startpage and Qwant are privacy alternatives. Google can exist as a user-selected fallback, but it should not define the browser.
 
-WhatsApp support matters. It should remain one of the strongest web-app profiles, especially for Linux users, but the browser should not become only a WhatsApp wrapper.
-
-## What this browser is trying to become
-
-A focused browser for people who want:
-
-- DuckDuckGo-first desktop browsing
-- Linux-first web app profiles
-- WhatsApp, GitHub, ChatGPT, Proton Mail, and similar apps in isolated sessions
-- clear privacy controls instead of hidden settings
-- encrypted local profile storage where the OS supports it
-- optional encrypted backup/sync direction
-- optional local-first AI assistance
-- no browser-vendor account requirement for basic usage
-- practical tools for builders, researchers, and power users
-
-## What it is not yet
-
-Zen Browser is not yet:
-
-- a full privacy browser
-- an anonymity tool
-- a hardened security browser
-- a complete replacement for mainstream browsers
-- a production-ready password/session manager
-- a proven WhatsApp calling solution across all accounts and future WhatsApp updates
+WhatsApp support matters. It should remain one of the strongest web-app profiles, especially for Linux users, but Hoo should not become only a WhatsApp wrapper.
 
 ## Core features in the prototype
 
@@ -90,10 +125,10 @@ Zen Browser is not yet:
 - HTTPS upgrade attempt for HTTP URLs
 - optional user-agent spoofing
 - configurable history retention
-- local storage through Electron `safeStorage` when available
+- local storage through Electron `safeStorage` where available
 - encryption status and encrypted backup/sync still need stronger implementation
 
-These controls are early. They should be treated as practical experiments, not strong privacy guarantees.
+These controls are early. Treat them as practical experiments, not strong privacy guarantees.
 
 See [`docs/encryption-plan.md`](docs/encryption-plan.md).
 
@@ -103,23 +138,46 @@ See [`docs/encryption-plan.md`](docs/encryption-plan.md).
 - local gateway status check
 - current page title and URL can be passed as context
 
-The AI layer should remain explicit and user-controlled. The browser should not silently scrape or send page content.
+The AI layer must remain explicit and user-controlled. Hoo should not silently scrape or send page content.
 
-### Other tools
-
-- bookmarks
-- RSS reader
-- dashboard
-- MEGA profile sync experiment
-
-## Setup
+## Install on Linux
 
 Requirements:
 
 - Node.js 18 or newer
 - npm 9 or newer
-- Electron-supported desktop OS
-- Linux recommended for the current direction
+- Git
+- Electron-supported Linux desktop
+
+Install directly from GitHub:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/imranshiundu/Hoo-browser/main/scripts/install-hoo.sh | bash
+```
+
+The installer:
+
+- clones Hoo into `~/.local/share/hoo-browser`
+- installs dependencies
+- builds the Electron app
+- creates a `hoo-browser` launcher in `~/.local/bin`
+- creates a desktop launcher so Hoo appears in the app menu
+- installs a user-level systemd timer that checks for updates every 7 days
+
+Start it from your app launcher or run:
+
+```bash
+hoo-browser
+```
+
+## Development setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/imranshiundu/Hoo-browser.git
+cd Hoo-browser
+```
 
 Install dependencies:
 
@@ -163,15 +221,28 @@ Only use the unsafe no-sandbox command when debugging a local environment that r
 npm run start:unsafe-no-sandbox
 ```
 
+## Packaging
+
+Early packaging scripts are available:
+
+```bash
+npm run dist
+npm run dist:appimage
+npm run dist:deb
+```
+
+Packaging still needs clean-machine verification before public release builds should be advertised.
+
 ## Project structure
 
 ```text
 src/
   main/        Electron main process, BrowserView management, storage, sync, privacy filters
   preload/     safe bridge exposed to the renderer
-  renderer/    React interface, views, panels, navigation, settings
+  renderer/    React interface, views, panels, navigation, settings, branding assets
 
 docs/
+  branding/                  README and brand assets
   encryption-plan.md
   real-browser-checklist.md
   rebuild-plan.md
@@ -184,7 +255,7 @@ Do not commit personal machine paths such as `/home/imran/...` or private local 
 Use generic paths only:
 
 ```text
-~/.config/zen-browser
+~/.config/hoo-browser
 /path/to/openclaw/docker-compose.yml
 ```
 
@@ -192,30 +263,31 @@ Local developer paths can exist in a private `.env` or ignored local config file
 
 ## Known problems
 
-These are not small issues. They are the reason the browser needs a rebuild path.
+These are not small issues. They are why Hoo still needs a rebuild path.
 
 1. The ad/tracker blocker uses a small hard-coded list, not maintained filter lists.
 2. Random user-agent rotation can make fingerprinting worse if used incorrectly.
-3. Some README claims were stronger than the implementation.
-4. The project has no automated tests yet.
-5. RSS currently depends on renderer-side fetching patterns that should move to the main process.
-6. Cloud sync needs stronger conflict handling and clearer data boundaries.
-7. IPC actions need tighter validation as the browser grows.
-8. Packaging is not ready for normal users.
-9. The app needs a clean release mode that does not behave like a development build.
-10. Hard-coded local developer assumptions must be moved into user-configurable settings.
+3. Download manager UI is not complete yet.
+4. Permission prompts for camera, microphone, notifications, location, and clipboard need a visible Hoo-controlled UX.
+5. Crash recovery needs implementation.
+6. The project has no automated tests yet.
+7. RSS currently depends on renderer-side fetching patterns that should move to the main process.
+8. Cloud sync needs stronger conflict handling and clearer data boundaries.
+9. IPC actions need tighter validation as the browser grows.
+10. AppImage/deb builds need clean-machine verification.
 
 ## Rebuild path
 
 Use simple version names:
 
 - `v0.1 Foundation` — honest docs, build scripts, verification, project contract
-- `v0.2 Stable Tabs` — reliable tab restore, navigation state, crash handling
-- `v0.3 Web Apps` — isolated app profiles, permissions, reset controls
-- `v0.4 Privacy Controls` — maintained filters, allowlists, visible blocked counts, stable fingerprint profile
-- `v0.5 Local Assistant` — streaming, explicit context, provider settings, local/cloud warnings
-- `v0.6 Sync and Encryption` — safe sync scope, conflict handling, encrypted backup/import/export
-- `v0.7 Packaging` — AppImage, deb, icons, desktop entry
+- `v0.2 Hoo Foundation` — Hoo identity, installer path, branded home UI, packaging metadata
+- `v0.3 Stable Tabs` — reliable tab restore, navigation state, crash handling
+- `v0.4 Web Apps` — isolated app profiles, permissions, reset controls
+- `v0.5 Privacy Controls` — maintained filters, allowlists, visible blocked counts, stable fingerprint profile
+- `v0.6 Local Assistant` — streaming, explicit context, provider settings, local/cloud warnings
+- `v0.7 Sync and Encryption` — safe sync scope, conflict handling, encrypted backup/import/export
+- `v0.8 Packaging` — verified AppImage, deb, icons, desktop entry
 - `v1.0 Daily Driver` — only after stability, packaging, tests, and privacy docs match behavior
 
 Read the detailed plan in [`docs/rebuild-plan.md`](docs/rebuild-plan.md).

--- a/docs/branding/hoo-branding.svg
+++ b/docs/branding/hoo-branding.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 520" role="img" aria-label="Hoo Browser brand banner">
+  <defs>
+    <radialGradient id="bg" cx="35%" cy="30%" r="90%"><stop offset="0" stop-color="#172126"/><stop offset="1" stop-color="#0E1111"/></radialGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FF8A19"/><stop offset="1" stop-color="#FF6A00"/></linearGradient>
+  </defs>
+  <rect width="1600" height="520" rx="36" fill="url(#bg)"/>
+  <g transform="translate(110 93) scale(.72)">
+    <rect width="430" height="430" rx="96" fill="#171B1D"/>
+    <circle cx="215" cy="215" r="145" fill="#202426"/>
+    <path d="M62 85c56 10 100 34 135 73-62-5-107-30-135-73Z" fill="url(#orange)"/>
+    <path d="M368 85c-56 10-100 34-135 73 62-5 107-30 135-73Z" fill="url(#orange)"/>
+    <circle cx="164" cy="194" r="55" fill="#F2F2EF"/><circle cx="266" cy="194" r="55" fill="#F2F2EF"/>
+    <circle cx="164" cy="194" r="34" fill="#FF6A00"/><circle cx="266" cy="194" r="34" fill="#FF6A00"/>
+    <circle cx="164" cy="194" r="25" fill="#101415"/><circle cx="266" cy="194" r="25" fill="#101415"/>
+    <circle cx="153" cy="182" r="8" fill="#fff"/><circle cx="255" cy="182" r="8" fill="#fff"/>
+    <path d="M215 213l-20 30c13 10 27 10 40 0l-20-30Z" fill="url(#orange)"/>
+    <path d="M150 124c30 12 50 26 65 44 15-18 35-32 65-44-8 33-28 58-65 76-37-18-57-43-65-76Z" fill="url(#orange)"/>
+    <path d="M145 295c47 32 93 32 140 0-9 42-35 70-70 70s-61-28-70-70Z" fill="#F2F2EF" opacity=".16"/>
+  </g>
+  <text x="455" y="220" fill="#F2F2EF" font-family="Inter, Arial, sans-serif" font-size="106" font-weight="800" letter-spacing="-5">Hoo</text>
+  <text x="680" y="220" fill="#F2F2EF" opacity=".86" font-family="Inter, Arial, sans-serif" font-size="96" font-weight="300" letter-spacing="-5">Browser</text>
+  <text x="460" y="300" fill="#8EB876" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" letter-spacing="13">OWL-GUIDED. PRIVACY-FIRST. WEB FREEDOM.</text>
+  <text x="460" y="370" fill="#B8BEC3" font-family="Inter, Arial, sans-serif" font-size="29">DuckDuckGo-first desktop browser with isolated web apps, practical protection,</text>
+  <text x="460" y="410" fill="#B8BEC3" font-family="Inter, Arial, sans-serif" font-size="29">and a calm owl-guided experience for Linux and beyond.</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "zen-browser",
-  "version": "0.1.0",
-  "description": "A desktop browser experiment built with Electron, focused on practical privacy controls, Linux web-app compatibility, and local-first AI assistance.",
+  "name": "hoo-browser",
+  "version": "0.2.0",
+  "productName": "Hoo Browser",
+  "description": "Owl-guided, DuckDuckGo-first desktop browser focused on practical privacy, isolated web apps, and Linux-first freedom.",
   "main": "dist/main/main.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
@@ -11,17 +12,43 @@
     "start:unsafe-no-sandbox": "electron . --no-sandbox",
     "dev:start": "npm run build && npm run start",
     "typecheck": "tsc --noEmit",
-    "verify": "npm run typecheck && npm run build"
+    "verify": "npm run typecheck && npm run build",
+    "dist": "npm run build:prod && electron-builder --linux AppImage deb",
+    "dist:appimage": "npm run build:prod && electron-builder --linux AppImage",
+    "dist:deb": "npm run build:prod && electron-builder --linux deb"
   },
   "keywords": [
     "electron",
     "browser",
     "privacy",
+    "duckduckgo",
     "linux",
-    "desktop-app"
+    "desktop-app",
+    "hoo"
   ],
   "author": "Imran Shiundu",
   "license": "MIT",
+  "build": {
+    "appId": "com.imranshiundu.hoo-browser",
+    "productName": "Hoo Browser",
+    "artifactName": "Hoo-Browser-${version}.${ext}",
+    "directories": {
+      "output": "release"
+    },
+    "files": [
+      "dist/**/*",
+      "package.json"
+    ],
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ],
+      "category": "Network",
+      "synopsis": "Owl-guided privacy-first desktop browser",
+      "description": "Hoo Browser is a DuckDuckGo-first desktop browser focused on practical privacy, isolated web apps, and a calm owl-guided browsing experience."
+    }
+  },
   "devDependencies": {
     "@types/electron": "^1.4.38",
     "@types/node": "^25.2.0",

--- a/scripts/install-hoo.sh
+++ b/scripts/install-hoo.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME="Hoo Browser"
+APP_ID="hoo-browser"
+REPO_URL="${HOO_REPO_URL:-https://github.com/imranshiundu/Hoo-browser.git}"
+BRANCH="${HOO_BRANCH:-main}"
+INSTALL_DIR="${HOO_INSTALL_DIR:-$HOME/.local/share/hoo-browser}"
+BIN_DIR="$HOME/.local/bin"
+DESKTOP_DIR="$HOME/.local/share/applications"
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+LAUNCHER="$BIN_DIR/hoo-browser"
+DESKTOP_FILE="$DESKTOP_DIR/hoo-browser.desktop"
+UPDATE_SCRIPT="$INSTALL_DIR/scripts/update-hoo.sh"
+SERVICE_FILE="$SYSTEMD_DIR/hoo-browser-update.service"
+TIMER_FILE="$SYSTEMD_DIR/hoo-browser-update.timer"
+
+info() { printf '\033[1;34m[Hoo]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[Hoo warning]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[Hoo error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+need_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
+
+ensure_linux_desktop() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    fail "This installer currently supports Linux desktop systems only."
+  fi
+}
+
+install_system_packages_hint() {
+  if command -v apt >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo apt update && sudo apt install -y git nodejs npm"
+  elif command -v dnf >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo dnf install -y git nodejs npm"
+  elif command -v pacman >/dev/null 2>&1; then
+    warn "If installation fails because Node.js/npm/git is missing, run: sudo pacman -S git nodejs npm"
+  fi
+}
+
+clone_or_update_repo() {
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  if [[ -d "$INSTALL_DIR/.git" ]]; then
+    info "Existing installation found at $INSTALL_DIR"
+    git -C "$INSTALL_DIR" fetch origin "$BRANCH"
+    git -C "$INSTALL_DIR" checkout "$BRANCH"
+    git -C "$INSTALL_DIR" pull --ff-only origin "$BRANCH"
+  else
+    info "Cloning Hoo Browser from $REPO_URL"
+    git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+  fi
+}
+
+build_app() {
+  info "Installing dependencies"
+  npm --prefix "$INSTALL_DIR" install
+  info "Building Hoo Browser"
+  npm --prefix "$INSTALL_DIR" run build
+}
+
+write_launcher() {
+  mkdir -p "$BIN_DIR"
+  cat > "$LAUNCHER" <<EOF
+#!/usr/bin/env bash
+set -e
+cd "$INSTALL_DIR"
+exec npm start -- "\$@"
+EOF
+  chmod +x "$LAUNCHER"
+  info "Launcher installed at $LAUNCHER"
+}
+
+write_desktop_entry() {
+  mkdir -p "$DESKTOP_DIR"
+  cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Name=$APP_NAME
+Comment=Owl-guided DuckDuckGo-first browser with isolated web apps
+Exec=$LAUNCHER
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+StartupNotify=true
+StartupWMClass=Hoo Browser
+Icon=web-browser
+Keywords=browser;web;duckduckgo;privacy;hoo;owl;
+EOF
+  chmod 644 "$DESKTOP_FILE"
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$DESKTOP_DIR" >/dev/null 2>&1 || true
+  fi
+  info "Desktop entry installed at $DESKTOP_FILE"
+}
+
+write_update_timer() {
+  mkdir -p "$SYSTEMD_DIR"
+  cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Update Hoo Browser from GitHub
+Documentation=https://github.com/imranshiundu/Hoo-browser
+
+[Service]
+Type=oneshot
+Environment=HOO_INSTALL_DIR=$INSTALL_DIR
+Environment=HOO_BRANCH=$BRANCH
+ExecStart=$UPDATE_SCRIPT --quiet
+EOF
+
+  cat > "$TIMER_FILE" <<EOF
+[Unit]
+Description=Run Hoo Browser update check every 7 days
+
+[Timer]
+OnBootSec=20min
+OnUnitActiveSec=7d
+Persistent=true
+Unit=hoo-browser-update.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user daemon-reload || warn "Could not reload user systemd daemon. You may need to log out and back in."
+    systemctl --user enable --now hoo-browser-update.timer || warn "Could not enable update timer automatically. Run: systemctl --user enable --now hoo-browser-update.timer"
+    info "7-day update timer installed: hoo-browser-update.timer"
+  else
+    warn "systemd user timers are unavailable. You can update manually with: $UPDATE_SCRIPT"
+  fi
+}
+
+main() {
+  ensure_linux_desktop
+  install_system_packages_hint
+  need_command git
+  need_command npm
+  need_command node
+  clone_or_update_repo
+  build_app
+  write_launcher
+  write_desktop_entry
+  write_update_timer
+  info "Installation complete. Start Hoo Browser from your app launcher or run: hoo-browser"
+}
+
+main "$@"

--- a/scripts/update-hoo.sh
+++ b/scripts/update-hoo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+INSTALL_DIR="${HOO_INSTALL_DIR:-$HOME/.local/share/hoo-browser}"
+BRANCH="${HOO_BRANCH:-main}"
+QUIET="${1:-}"
+
+info() { [[ "$QUIET" == "--quiet" ]] || printf '\033[1;34m[Hoo update]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[Hoo update warning]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[Hoo update error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ -d "$INSTALL_DIR/.git" ]] || fail "No git install found at $INSTALL_DIR"
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v npm >/dev/null 2>&1 || fail "npm is required"
+
+cd "$INSTALL_DIR"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  warn "Local changes detected. Skipping automatic update to avoid overwriting work."
+  exit 0
+fi
+
+info "Checking GitHub for updates"
+git fetch origin "$BRANCH"
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "origin/$BRANCH")"
+
+if [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]]; then
+  info "Hoo Browser is already up to date."
+  exit 0
+fi
+
+info "Updating Hoo Browser"
+git pull --ff-only origin "$BRANCH"
+npm install
+npm run build
+info "Update complete. Restart Hoo Browser to use the new version."

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,8 @@ import { StorageService, StorageData } from "./storage";
 import { setupAuthHandlers } from "./auth";
 import { MegaSyncService } from "./sync";
 
+app.setName("Hoo Browser");
+
 let mainWindow: BrowserWindow | null = null;
 const browserViews: Map<string, BrowserView> = new Map();
 let activeTabId: string | null = null;
@@ -52,7 +54,7 @@ function attachViewHandlers(tabId: string, view: BrowserView) {
             view.webContents.executeJavaScript(`
                 Object.defineProperty(navigator, 'platform', { get: () => 'Win32' });
                 Object.defineProperty(navigator, 'userAgent', { get: () => '${WHATSAPP_UA}' });
-                console.log('[Zen] Windows environment spoofed.');
+                console.log('[Hoo] Windows environment spoofed.');
             `);
         } else {
             view.webContents.setUserAgent(getRandomUserAgent());
@@ -108,8 +110,10 @@ function createWindow() {
     mainWindow = new BrowserWindow({
         height: 800,
         width: 1400,
-        frame: false, // Frameless window
-        titleBarStyle: 'hidden', // Hide title bar but keep traffic lights on Mac (if any)
+        frame: false,
+        title: "Hoo Browser",
+        backgroundColor: "#0E1111",
+        titleBarStyle: 'hidden',
         webPreferences: {
             preload: path.join(__dirname, "../preload/preload.js"),
             nodeIntegration: false,
@@ -119,7 +123,9 @@ function createWindow() {
     });
 
     mainWindow.loadFile(path.join(__dirname, "../renderer/index.html"));
-    mainWindow.webContents.openDevTools(); // Temporary for development
+    if (!app.isPackaged && process.env.HOO_OPEN_DEVTOOLS === '1') {
+        mainWindow.webContents.openDevTools();
+    }
 
     setupPrivacyFilters();
     setupAuthHandlers(mainWindow);
@@ -188,7 +194,7 @@ function applyPrivacyToSession(ses: Electron.Session) {
     ses.webRequest.onBeforeRequest(filter, (details, callback) => {
         // 1. Ad Shield logic
         if (privacySettings.adShield && shouldBlockRequest(details.url)) {
-            console.log('[Zen Shield] Blocked:', details.url);
+            console.log('[Hoo Shield] Blocked:', details.url);
             return callback({ cancel: true });
         }
 
@@ -457,7 +463,7 @@ ipcMain.handle('get-system-metrics', async () => {
 });
 
 ipcMain.handle('nuclear-wipe', async () => {
-    console.log('☢️ NUCLEAR WIPE INITIATED');
+    console.log('NUCLEAR WIPE INITIATED');
 
     // 1. Clear session data (Cookies, Cache, etc.)
     await session.defaultSession.clearStorageData();

--- a/src/renderer/assets/branding/hoo-app-icon.svg
+++ b/src/renderer/assets/branding/hoo-app-icon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Hoo Browser owl icon">
+  <defs>
+    <radialGradient id="bg" cx="45%" cy="30%" r="80%">
+      <stop offset="0" stop-color="#2A2F33"/>
+      <stop offset="1" stop-color="#0E1111"/>
+    </radialGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FF8A19"/>
+      <stop offset="1" stop-color="#FF6A00"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <circle cx="256" cy="252" r="168" fill="#171B1D" filter="url(#shadow)"/>
+  <path d="M73 113c62 10 112 35 151 80C156 187 104 160 73 113Z" fill="url(#orange)"/>
+  <path d="M439 113c-62 10-112 35-151 80 68-6 120-33 151-80Z" fill="url(#orange)"/>
+  <path d="M109 180c41-79 113-110 147-111 34 1 106 32 147 111-53-25-98-21-147 7-49-28-94-32-147-7Z" fill="#202426"/>
+  <path d="M114 222c41-86 108-115 142-115s101 29 142 115c-31 102-85 160-142 160s-111-58-142-160Z" fill="#202426"/>
+  <path d="M165 216c20-54 58-82 91-82s71 28 91 82c-21 62-55 98-91 98s-70-36-91-98Z" fill="#F2F2EF"/>
+  <circle cx="195" cy="224" r="64" fill="#F2F2EF"/>
+  <circle cx="317" cy="224" r="64" fill="#F2F2EF"/>
+  <circle cx="195" cy="224" r="39" fill="#FF6A00"/>
+  <circle cx="317" cy="224" r="39" fill="#FF6A00"/>
+  <circle cx="195" cy="224" r="29" fill="#101415"/>
+  <circle cx="317" cy="224" r="29" fill="#101415"/>
+  <circle cx="183" cy="211" r="10" fill="#fff" opacity="0.92"/>
+  <circle cx="305" cy="211" r="10" fill="#fff" opacity="0.92"/>
+  <path d="M256 247l-24 33c15 12 33 12 48 0l-24-33Z" fill="url(#orange)"/>
+  <path d="M178 141c33 12 58 26 78 46 20-20 45-34 78-46-11 36-35 62-78 81-43-19-67-45-78-81Z" fill="url(#orange)"/>
+  <path d="M184 338c47 36 97 36 144 0-8 50-36 83-72 83s-64-33-72-83Z" fill="#3A2F24" opacity="0.58"/>
+  <path d="M318 334h28v18h-28v-18Zm10-34h18v76h-18v-76Z" fill="#FF6A00" opacity="0.9"/>
+</svg>

--- a/src/renderer/assets/branding/hoo-wallpaper.svg
+++ b/src/renderer/assets/branding/hoo-wallpaper.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" role="img" aria-label="Hoo Browser owl wallpaper">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="52%" r="85%">
+      <stop offset="0" stop-color="#172126"/>
+      <stop offset="0.45" stop-color="#0E1111"/>
+      <stop offset="1" stop-color="#050706"/>
+    </radialGradient>
+    <radialGradient id="sun" cx="50%" cy="84%" r="45%">
+      <stop offset="0" stop-color="#FF6A00" stop-opacity="0.75"/>
+      <stop offset="0.28" stop-color="#FF6A00" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#FF6A00" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FF8A19"/><stop offset="1" stop-color="#FF6A00"/></linearGradient>
+    <filter id="softShadow"><feDropShadow dx="0" dy="26" stdDeviation="26" flood-color="#000" flood-opacity="0.55"/></filter>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#sky)"/>
+  <rect width="1920" height="1080" fill="url(#sun)"/>
+  <g opacity="0.28" fill="#F2F2EF">
+    <circle cx="260" cy="150" r="2"/><circle cx="520" cy="230" r="1.6"/><circle cx="820" cy="130" r="2"/><circle cx="1280" cy="190" r="1.5"/><circle cx="1510" cy="120" r="2"/><circle cx="1710" cy="270" r="1.8"/><circle cx="1080" cy="330" r="1.4"/>
+  </g>
+  <path d="M0 840c170-95 350-138 540-90 153 39 270 25 420-38 205-86 376-70 560 36 130 75 251 72 400 42v290H0V840Z" fill="#07100C"/>
+  <path d="M0 905c260-115 470-130 690-38 180 75 350 71 543 0 230-84 422-76 687 28v185H0V905Z" fill="#030504"/>
+  <path d="M520 736c220 19 501 23 856-4 90-7 174-19 266-32 18-3 28 24 11 32-370 161-750 169-1140 31-22-8-16-29 7-27Z" fill="#4A2E18"/>
+  <path d="M1324 714c74-80 128-104 174-116-26 46-64 87-133 126l-41-10Z" fill="#3DBB78" opacity="0.62"/>
+  <path d="M1374 726c58-33 109-41 155-33-35 27-82 45-140 47l-15-14Z" fill="#3DBB78" opacity="0.58"/>
+  <g transform="translate(760 188) scale(1.05)" filter="url(#softShadow)">
+    <ellipse cx="200" cy="278" rx="150" ry="188" fill="#171B1D"/>
+    <path d="M44 70c58 12 104 38 139 83-68-8-112-35-139-83Z" fill="url(#orange)"/>
+    <path d="M356 70c-58 12-104 38-139 83 68-8 112-35 139-83Z" fill="url(#orange)"/>
+    <path d="M70 166c39-74 97-104 130-105 33 1 91 31 130 105-48-22-88-17-130 10-42-27-82-32-130-10Z" fill="#202426"/>
+    <path d="M86 210c32-83 80-126 114-126s82 43 114 126c-29 91-68 139-114 139s-85-48-114-139Z" fill="#202426"/>
+    <ellipse cx="200" cy="254" rx="84" ry="112" fill="#F2F2EF" opacity="0.9"/>
+    <circle cx="148" cy="210" r="58" fill="#F2F2EF"/>
+    <circle cx="252" cy="210" r="58" fill="#F2F2EF"/>
+    <circle cx="148" cy="210" r="35" fill="#FF6A00"/><circle cx="252" cy="210" r="35" fill="#FF6A00"/>
+    <circle cx="148" cy="210" r="26" fill="#101415"/><circle cx="252" cy="210" r="26" fill="#101415"/>
+    <circle cx="137" cy="197" r="9" fill="#fff"/><circle cx="241" cy="197" r="9" fill="#fff"/>
+    <path d="M200 232l-22 32c14 11 30 11 44 0l-22-32Z" fill="url(#orange)"/>
+    <path d="M130 130c33 13 53 28 70 48 17-20 37-35 70-48-8 35-30 62-70 82-40-20-62-47-70-82Z" fill="url(#orange)"/>
+    <path d="M74 270c54 45 93 71 126 80-59 51-123 33-160-31l34-49Z" fill="#111415"/>
+    <path d="M272 270c-13 36-33 62-72 80 58 50 122 33 160-31l-88-49Z" fill="#111415"/>
+    <path d="M250 318h24v16h-24v-16Zm8-29h16v68h-16v-68Z" fill="#FF6A00"/>
+    <path d="M145 462c38 21 74 20 110 0" stroke="#FF6A00" stroke-width="12" stroke-linecap="round" opacity="0.55"/>
+  </g>
+  <text x="80" y="965" fill="#F2F2EF" opacity="0.74" font-family="Inter, Arial, sans-serif" font-size="22" letter-spacing="8">OWL-GUIDED · PRIVACY-FIRST · WEB FREEDOM</text>
+</svg>

--- a/src/renderer/views/Home.css
+++ b/src/renderer/views/Home.css
@@ -6,21 +6,19 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background:
-        radial-gradient(circle at 20% 20%, rgba(222, 88, 51, 0.16), transparent 34%),
-        radial-gradient(circle at 80% 10%, rgba(46, 204, 113, 0.13), transparent 30%),
-        linear-gradient(145deg, #050706 0%, #07110d 48%, #030504 100%);
+    background-color: #0E1111;
+    background-size: cover;
+    background-position: center;
     overflow: hidden;
+    color: #F2F2EF;
 }
 
-.home-grid {
+.home-vignette {
     position: absolute;
     inset: 0;
-    background-image:
-        linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
-    background-size: 44px 44px;
-    mask-image: radial-gradient(circle at center, black, transparent 72%);
+    background:
+        radial-gradient(circle at 50% 52%, rgba(255, 106, 0, 0.06), transparent 44%),
+        linear-gradient(180deg, rgba(14, 17, 17, 0.42), rgba(14, 17, 17, 0.82));
     pointer-events: none;
 }
 
@@ -29,17 +27,58 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 24px;
+    gap: 20px;
     padding: 32px;
     width: 100%;
     max-width: 980px;
     z-index: 2;
 }
 
+.brand-lockup {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 18px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(14, 17, 17, 0.38);
+    border: 1px solid rgba(242, 242, 239, 0.08);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+    backdrop-filter: blur(18px);
+}
+
+.brand-icon {
+    width: 68px;
+    height: 68px;
+    border-radius: 20px;
+    display: block;
+}
+
+.brand-wordmark {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    letter-spacing: -2.5px;
+}
+
+.brand-hoo {
+    font-size: clamp(48px, 7vw, 82px);
+    line-height: 1;
+    font-weight: 850;
+    color: #F2F2EF;
+}
+
+.brand-browser {
+    font-size: clamp(42px, 6vw, 74px);
+    line-height: 1;
+    font-weight: 250;
+    color: rgba(242, 242, 239, 0.82);
+}
+
 .product-pill {
-    background: rgba(255, 255, 255, 0.055);
-    backdrop-filter: blur(var(--blur));
-    border: 1px solid rgba(255, 255, 255, 0.09);
+    background: rgba(14, 17, 17, 0.55);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(141, 184, 118, 0.18);
     padding: 8px 14px;
     border-radius: var(--radius-full);
     display: flex;
@@ -48,7 +87,7 @@
     font-size: 10px;
     font-weight: 800;
     letter-spacing: 1.5px;
-    color: rgba(248, 250, 252, 0.72);
+    color: #8EB876;
 }
 
 .hero-copy {
@@ -57,36 +96,36 @@
 }
 
 .time {
-    font-size: clamp(64px, 10vw, 116px);
+    font-size: clamp(56px, 9vw, 106px);
     font-weight: 200;
     letter-spacing: -7px;
-    color: var(--text-primary);
+    color: #F2F2EF;
     line-height: 0.95;
     opacity: 0.96;
+    text-shadow: 0 18px 60px rgba(0, 0, 0, 0.7);
 }
 
 .greeting {
     margin-top: 12px;
-    font-size: 11px;
-    color: var(--text-secondary);
-    font-weight: 700;
-    letter-spacing: 4px;
-    text-transform: uppercase;
-    opacity: 0.7;
+    font-size: 22px;
+    color: #F2F2EF;
+    font-weight: 650;
+    letter-spacing: -0.5px;
+    opacity: 0.95;
 }
 
 .hero-copy h1 {
-    margin: 18px auto 0;
-    font-size: clamp(30px, 4.6vw, 58px);
-    line-height: 0.98;
-    letter-spacing: -2.4px;
+    margin: 10px auto 0;
+    font-size: clamp(26px, 4vw, 46px);
+    line-height: 1.04;
+    letter-spacing: -1.8px;
     max-width: 840px;
 }
 
 .hero-subtitle {
     max-width: 690px;
-    margin: 18px auto 0;
-    color: var(--text-secondary);
+    margin: 14px auto 0;
+    color: rgba(242, 242, 239, 0.68);
     font-size: 15px;
     line-height: 1.7;
 }
@@ -104,18 +143,18 @@
     width: 100%;
     display: flex;
     align-items: center;
-    background: rgba(8, 13, 10, 0.76);
-    backdrop-filter: blur(var(--blur));
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 24px;
-    padding: 7px;
+    background: rgba(23, 27, 29, 0.86);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(61, 187, 120, 0.18);
+    border-radius: 999px;
+    padding: 9px;
     transition: all var(--transition-normal);
     box-shadow: 0 34px 90px rgba(0, 0, 0, 0.48);
 }
 
 .search-container:focus-within {
-    border-color: rgba(222, 88, 51, 0.9);
-    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.55), 0 0 42px rgba(222, 88, 51, 0.16);
+    border-color: rgba(255, 106, 0, 0.88);
+    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.55), 0 0 44px rgba(255, 106, 0, 0.18);
     transform: translateY(-2px);
 }
 
@@ -125,11 +164,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #de5833;
-    background: rgba(222, 88, 51, 0.12);
-    border-radius: 18px;
+    color: #FF6A00;
+    background: rgba(255, 106, 0, 0.12);
+    border-radius: 50%;
     margin-right: 12px;
-    transition: all var(--transition-fast);
 }
 
 .search-input {
@@ -137,28 +175,31 @@
     background: transparent;
     border: none;
     outline: none;
-    color: var(--text-primary);
+    color: #F2F2EF;
     font-size: 16px;
     font-family: var(--font-family);
     padding: 13px 0;
 }
 
 .search-input::placeholder {
-    color: rgba(148, 163, 184, 0.7);
+    color: rgba(184, 190, 195, 0.78);
 }
 
 .search-submit {
-    background: #de5833;
+    background: #FF6A00;
     border: none;
     color: #fff;
-    width: 46px;
-    height: 46px;
-    border-radius: 17px;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
     transition: all var(--transition-fast);
+    font-size: 34px;
+    line-height: 0;
+    padding-bottom: 4px;
 }
 
 .search-submit:hover {
@@ -174,9 +215,9 @@
 }
 
 .engine-selectors button {
-    background: rgba(255, 255, 255, 0.035);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    color: var(--text-muted);
+    background: rgba(14, 17, 17, 0.52);
+    border: 1px solid rgba(242, 242, 239, 0.08);
+    color: rgba(242, 242, 239, 0.62);
     padding: 7px 12px;
     border-radius: var(--radius-full);
     font-size: 10px;
@@ -187,48 +228,24 @@
 }
 
 .engine-selectors button:hover {
-    color: var(--text-primary);
-    border-color: rgba(255, 255, 255, 0.2);
+    color: #F2F2EF;
+    border-color: rgba(242, 242, 239, 0.2);
 }
 
 .engine-selectors button.active {
-    background: var(--text-primary);
-    color: var(--bg-primary);
-    border-color: var(--text-primary);
+    background: #F2F2EF;
+    color: #0E1111;
+    border-color: #F2F2EF;
 }
 
 .engine-selectors button.primary-engine.active {
-    background: #de5833;
+    background: #FF6A00;
     color: #fff;
-    border-color: #de5833;
+    border-color: #FF6A00;
 }
 
 .fallback-engine {
     opacity: 0.68;
-}
-
-.trust-strip {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    justify-content: center;
-}
-
-.trust-strip div {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 9px 12px;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.075);
-    color: var(--text-secondary);
-    font-size: 12px;
-    font-weight: 600;
-}
-
-.trust-strip svg {
-    color: var(--accent-green);
 }
 
 .speed-dial {
@@ -251,38 +268,38 @@
 }
 
 .speed-dial-icon {
-    width: 58px;
-    height: 58px;
-    border-radius: 20px;
-    background: rgba(255, 255, 255, 0.045);
-    backdrop-filter: blur(var(--blur));
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    width: 74px;
+    height: 74px;
+    border-radius: 22px;
+    background: rgba(23, 27, 29, 0.74);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(242, 242, 239, 0.09);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--text-secondary);
+    color: #F2F2EF;
     transition: all var(--transition-normal);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.28);
 }
 
 .speed-dial-item:hover .speed-dial-icon {
     transform: translateY(-6px);
-    background: rgba(222, 88, 51, 0.11);
-    border-color: rgba(222, 88, 51, 0.6);
-    color: #de5833;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.42);
+    background: rgba(255, 106, 0, 0.12);
+    border-color: rgba(255, 106, 0, 0.62);
+    color: #FF6A00;
 }
 
 .speed-dial-label {
     font-size: 10px;
     font-weight: 800;
-    color: var(--text-muted);
+    color: rgba(242, 242, 239, 0.66);
     letter-spacing: 1.4px;
     text-transform: uppercase;
     transition: color var(--transition-fast);
 }
 
 .speed-dial-item:hover .speed-dial-label {
-    color: var(--text-primary);
+    color: #F2F2EF;
 }
 
 .home-footer {
@@ -291,19 +308,44 @@
     left: 36px;
     right: 36px;
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 30px;
     align-items: center;
     z-index: 10;
-    font-size: 10px;
-    color: rgba(148, 163, 184, 0.74);
-    letter-spacing: 1px;
-    text-transform: uppercase;
+    font-size: 13px;
+    color: rgba(242, 242, 239, 0.78);
+}
+
+.home-footer span {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    background: rgba(14, 17, 17, 0.48);
+    border: 1px solid rgba(61, 187, 120, 0.14);
+    backdrop-filter: blur(14px);
+}
+
+.home-footer svg {
+    color: #3DBB78;
 }
 
 @media (max-width: 760px) {
     .home-content {
         padding: 24px;
         gap: 18px;
+    }
+
+    .brand-lockup {
+        flex-direction: column;
+        border-radius: 32px;
+    }
+
+    .brand-wordmark {
+        flex-direction: column;
+        align-items: center;
+        gap: 0;
     }
 
     .hero-copy h1 {

--- a/src/renderer/views/Home.tsx
+++ b/src/renderer/views/Home.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import './Home.css';
-import { Search, Lock, Github, MessageSquare, Mail, Video, Newspaper, Shield, Globe2, KeyRound } from 'lucide-react';
+import { Search, Lock, Github, MessageSquare, Mail, Video, Newspaper, Shield, Globe2, KeyRound, Plus } from 'lucide-react';
+
+const hooIcon = require('../assets/branding/hoo-app-icon.svg');
+const hooWallpaper = require('../assets/branding/hoo-wallpaper.svg');
 
 const Home: React.FC = () => {
     const [time, setTime] = useState(new Date());
@@ -25,17 +28,17 @@ const Home: React.FC = () => {
             url = 'https://' + query;
         } else {
             switch (activeEngine) {
-                case 'duckduckgo':
-                    url = `https://duckduckgo.com/?q=${encodeURIComponent(query)}`;
-                    break;
                 case 'startpage':
                     url = `https://www.startpage.com/search?q=${encodeURIComponent(query)}`;
                     break;
                 case 'qwant':
                     url = `https://www.qwant.com/?q=${encodeURIComponent(query)}`;
                     break;
-                default:
+                case 'google':
                     url = `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+                    break;
+                default:
+                    url = `https://duckduckgo.com/?q=${encodeURIComponent(query)}`;
             }
         }
 
@@ -46,17 +49,17 @@ const Home: React.FC = () => {
 
     const getGreeting = () => {
         const hour = time.getHours();
-        if (hour < 12) return 'Good morning';
-        if (hour < 18) return 'Good afternoon';
-        return 'Good evening';
+        if (hour < 12) return "Good morning. Hoo's got your back.";
+        if (hour < 18) return "Good afternoon. Hoo's watching the web with you.";
+        return 'Good evening. Night mode suits an owl.';
     };
 
     const speedDialLinks = [
         { icon: MessageSquare, label: 'WhatsApp', url: 'https://web.whatsapp.com' },
         { icon: Github, label: 'GitHub', url: 'https://github.com' },
+        { icon: Video, label: 'YouTube', url: 'https://youtube.com' },
+        { icon: Newspaper, label: 'Reddit', url: 'https://reddit.com' },
         { icon: Mail, label: 'Proton', url: 'https://mail.proton.me' },
-        { icon: Video, label: 'Invidious', url: 'https://invidious.io' },
-        { icon: Newspaper, label: 'News', url: 'https://news.ycombinator.com' },
     ];
 
     const handleSpeedDialClick = (url: string) => {
@@ -75,39 +78,42 @@ const Home: React.FC = () => {
     };
 
     return (
-        <div className="home-container">
-            <div className="home-grid" />
+        <div className="home-container" style={{ backgroundImage: `url(${hooWallpaper.default || hooWallpaper})` }}>
+            <div className="home-vignette" />
             <div className="home-content animate-fade-in">
+                <div className="brand-lockup">
+                    <img src={hooIcon.default || hooIcon} alt="Hoo Browser owl icon" className="brand-icon" />
+                    <div className="brand-wordmark" aria-label="Hoo Browser">
+                        <span className="brand-hoo">Hoo</span><span className="brand-browser">Browser</span>
+                    </div>
+                </div>
+
                 <div className="product-pill">
                     <Shield size={14} />
-                    <span>DUCKDUCKGO-FIRST · LOCAL PROFILE · WEB APP READY</span>
+                    <span>OWL-GUIDED · PRIVACY-FIRST · WEB FREEDOM</span>
                 </div>
 
                 <section className="hero-copy">
                     <div className="time">{time.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}</div>
-                    <p className="greeting">{getGreeting()}, Zen User</p>
-                    <h1>Browse clean. Keep apps separate. Search with DuckDuckGo.</h1>
+                    <p className="greeting">{getGreeting()}</p>
+                    <h1>Private search. No tracking. Just results.</h1>
                     <p className="hero-subtitle">
-                        A Linux-first browser shell for private search, isolated web apps, practical shields, and encrypted local profile storage where your OS supports it.
+                        Hoo is a DuckDuckGo-first desktop browser for isolated web apps, practical protection, calm navigation, and Linux-first freedom.
                     </p>
                 </section>
 
                 <div className="search-stack">
                     <form onSubmit={handleSearch} className="search-container">
-                        <div className="search-engine-preview">
-                            {getEngineIcon()}
-                        </div>
+                        <div className="search-engine-preview">{getEngineIcon()}</div>
                         <input
                             type="text"
-                            placeholder="Search DuckDuckGo or enter a URL"
+                            placeholder="Search with DuckDuckGo or enter an address"
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
                             className="search-input"
                             autoFocus
                         />
-                        <button type="submit" className="search-submit" aria-label="Search or navigate">
-                            <Search size={18} />
-                        </button>
+                        <button type="submit" className="search-submit" aria-label="Search or navigate">›</button>
                     </form>
 
                     <div className="engine-selectors" aria-label="Search engine selector">
@@ -116,12 +122,6 @@ const Home: React.FC = () => {
                         <button className={activeEngine === 'qwant' ? 'active' : ''} onClick={() => setActiveEngine('qwant')}>Qwant</button>
                         <button className={activeEngine === 'google' ? 'active fallback-engine' : 'fallback-engine'} onClick={() => setActiveEngine('google')}>Google fallback</button>
                     </div>
-                </div>
-
-                <div className="trust-strip">
-                    <div><Shield size={16} /><span>Practical shields</span></div>
-                    <div><KeyRound size={16} /><span>Encryption-aware storage</span></div>
-                    <div><MessageSquare size={16} /><span>WhatsApp profile</span></div>
                 </div>
 
                 <div className="speed-dial">
@@ -134,12 +134,17 @@ const Home: React.FC = () => {
                             </button>
                         );
                     })}
+                    <button className="speed-dial-item add-app" type="button">
+                        <div className="speed-dial-icon"><Plus size={24} /></div>
+                        <span className="speed-dial-label">Add App</span>
+                    </button>
                 </div>
             </div>
 
             <div className="home-footer">
-                <span>Zen Browser Foundation</span>
-                <span>Daily-driver status: prototype, hardening in progress</span>
+                <span><Shield size={16} /> DuckDuckGo-first</span>
+                <span><KeyRound size={16} /> Website protection</span>
+                <span><Globe2 size={16} /> Linux-first</span>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

This PR applies the Hoo Browser brand system directly into the repo so the installed browser starts with the owl-led identity instead of the old Zen look.

## Added

- `src/renderer/assets/branding/hoo-app-icon.svg`
- `src/renderer/assets/branding/hoo-wallpaper.svg`
- `docs/branding/hoo-branding.svg`
- `scripts/install-hoo.sh`
- `scripts/update-hoo.sh`

## Updated

- Rebrands `package.json` to `hoo-browser` / `Hoo Browser`
- Adds AppImage/deb packaging scripts and electron-builder Linux metadata
- Rebuilds the home/new-tab UI around the exact Hoo color direction:
  - Hoo Orange `#FF6A00`
  - Leaf Green `#3DBB78`
  - Feather Cream `#F2F2EF`
  - Forest Black `#0E1111`
  - Slate Charcoal `#171B1D`
- Adds the Hoo owl app icon to the home UI
- Adds a separate owl-on-branch wallpaper asset for the new tab screen
- Updates README with the Hoo banner, brand system, install command, packaging notes, and current honest status
- Sets Electron app name/title to Hoo Browser
- Removes forced DevTools opening unless `HOO_OPEN_DEVTOOLS=1` is set in development

## Install command after merge

```bash
curl -fsSL https://raw.githubusercontent.com/imranshiundu/Hoo-browser/main/scripts/install-hoo.sh | bash
```

## Note

The assets are original repo SVG assets built from the approved brand direction, not cropped from the provided brand board image.

## Next patches after this

1. Main-process download manager event capture + Downloads UI
2. Hoo-styled permission prompt system
3. Crash capture and restore screen
4. Maintained privacy filter updater
5. Replace hard-coded OpenClaw local path assumptions
